### PR TITLE
feat(dashboard): implement instructor dashboard shell with sidebar, header and notification modal 

### DIFF
--- a/frontend-v2/app/student/dashboard/layout.tsx
+++ b/frontend-v2/app/student/dashboard/layout.tsx
@@ -1,0 +1,9 @@
+import { InstructorDashboardLayout } from "@/src/components/dashboard/instructor/InstructorDashboardLayout";
+
+export default function StudentDashboardLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return <InstructorDashboardLayout>{children}</InstructorDashboardLayout>;
+}

--- a/frontend-v2/app/student/dashboard/page.tsx
+++ b/frontend-v2/app/student/dashboard/page.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { BookOpen, Users, Clock, TrendingUp } from "lucide-react";
+
+export default function InstructorDashboardPage() {
+    const stats = [
+        {
+            title: "Total Students",
+            value: "1,284",
+            change: "+12.5%",
+            icon: Users,
+            color: "text-blue-600",
+            bg: "bg-blue-50",
+        },
+        {
+            title: "Active Courses",
+            value: "12",
+            change: "+2",
+            icon: BookOpen,
+            color: "text-indigo-600",
+            bg: "bg-indigo-50",
+        },
+        {
+            title: "Total Hours",
+            value: "456",
+            change: "+48h",
+            icon: Clock,
+            color: "text-purple-600",
+            bg: "bg-purple-50",
+        },
+        {
+            title: "Earnings",
+            value: "2,450 XLM",
+            change: "+18%",
+            icon: TrendingUp,
+            color: "text-green-600",
+            bg: "bg-green-50",
+        },
+    ];
+
+    return (
+        <div className="space-y-8">
+            <div>
+                <h2 className="text-3xl font-bold text-gray-900">Dashboard Overview</h2>
+                <p className="text-gray-500 mt-2">Here is what is happening with your courses today.</p>
+            </div>
+
+            {/* Stats Grid */}
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+                {stats.map((stat) => (
+                    <Card key={stat.title} className="border-none shadow-sm hover:shadow-md transition-shadow duration-300">
+                        <CardHeader className="flex flex-row items-center justify-between pb-2 space-y-0">
+                            <CardTitle className="text-sm font-medium text-gray-500">{stat.title}</CardTitle>
+                            <div className={`${stat.bg} p-2 rounded-lg`}>
+                                <stat.icon className={`h-4 w-4 ${stat.color}`} />
+                            </div>
+                        </CardHeader>
+                        <CardContent>
+                            <div className="text-2xl font-bold text-gray-900">{stat.value}</div>
+                            <p className="text-xs text-green-600 mt-1 font-semibold">
+                                {stat.change} <span className="text-gray-400 font-normal ml-1">since last month</span>
+                            </p>
+                        </CardContent>
+                    </Card>
+                ))}
+            </div>
+
+            {/* Content Placeholders */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+                <Card className="border-none shadow-sm h-96">
+                    <CardHeader>
+                        <CardTitle>Recent Enrollments</CardTitle>
+                    </CardHeader>
+                    <CardContent className="flex items-center justify-center h-full -mt-10">
+                        <div className="text-center">
+                            <div className="w-16 h-16 bg-gray-50 rounded-full flex items-center justify-center mx-auto mb-4">
+                                <Users className="text-gray-300" />
+                            </div>
+                            <p className="text-gray-400 text-sm">No recent enrollments to show.</p>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <Card className="border-none shadow-sm h-96">
+                    <CardHeader>
+                        <CardTitle>Upcoming Sessions</CardTitle>
+                    </CardHeader>
+                    <CardContent className="flex items-center justify-center h-full -mt-10">
+                        <div className="text-center">
+                            <div className="w-16 h-16 bg-gray-50 rounded-full flex items-center justify-center mx-auto mb-4">
+                                <Clock className="text-gray-300" />
+                            </div>
+                            <p className="text-gray-400 text-sm">No upcoming sessions scheduled.</p>
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        </div>
+    );
+}

--- a/frontend-v2/src/components/dashboard/instructor/Header.tsx
+++ b/frontend-v2/src/components/dashboard/instructor/Header.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import React, { useState } from "react";
+import { Search, Bell, Copy, ChevronDown, Menu } from "lucide-react";
+import { NotificationModal } from "./NotificationModal";
+
+interface HeaderProps {
+    onMenuToggle?: () => void;
+}
+
+export const Header: React.FC<HeaderProps> = ({ onMenuToggle }) => {
+    const [isNotifOpen, setIsNotifOpen] = useState(false);
+    const instructor = {
+        name: "Smith",
+        fullName: "Professor Smith",
+        wallet: "0xdf287d3a0c12b9a56",
+        avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Smith"
+    };
+
+    const truncatedWallet = `${instructor.wallet.slice(0, 5)}...${instructor.wallet.slice(-4)}`;
+
+    return (
+        <header className="h-20 bg-white border-b border-gray-100 flex items-center justify-between px-4 lg:px-8 sticky top-0 z-30">
+            {/* Mobile hamburger */}
+            {onMenuToggle && (
+                <button
+                    onClick={onMenuToggle}
+                    className="mr-3 p-2 rounded-xl border border-gray-100 hover:bg-gray-50 lg:hidden"
+                    aria-label="Toggle sidebar"
+                >
+                    <Menu size={20} className="text-gray-500" />
+                </button>
+            )}
+            <div className="flex-1 max-w-xl">
+                <h1 className="text-xl font-bold text-gray-900 mb-1 leading-tight">
+                    Good day, {instructor.name}
+                </h1>
+                <p className="text-xs text-gray-400 font-medium tracking-wide">Welcome back to your dashboard</p>
+            </div>
+
+            <div className="flex items-center gap-8">
+                {/* Search Bar */}
+                <div className="relative hidden lg:block group">
+                    <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 group-focus-within:text-indigo-600 transition-colors" />
+                    <input
+                        type="text"
+                        placeholder="Search everything..."
+                        className="pl-12 pr-4 py-2.5 w-72 rounded-xl border border-gray-100 bg-gray-50/50 text-sm focus:outline-none focus:ring-4 focus:ring-indigo-500/10 focus:border-indigo-500 focus:bg-white transition-all duration-300"
+                    />
+                </div>
+
+                <div className="flex items-center gap-6 border-l border-gray-100 pl-8">
+                    {/* Wallet Address */}
+                    <button className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-indigo-50/50 border border-indigo-100 text-[11px] font-mono font-bold text-indigo-600 hover:bg-indigo-100 transition-colors duration-200 group">
+                        <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse ring-4 ring-green-500/20" />
+                        {truncatedWallet}
+                        <Copy size={12} className="ml-1 opacity-60 group-hover:opacity-100 transition-opacity" />
+                    </button>
+
+                    {/* Notification Bell */}
+                    <div className="relative">
+                        <button
+                            onClick={() => setIsNotifOpen(!isNotifOpen)}
+                            className={`p-2.5 rounded-xl border transition-all duration-200 relative group ${isNotifOpen
+                                ? 'bg-indigo-50 border-indigo-200'
+                                : 'bg-white border-gray-100 hover:bg-gray-50 hover:border-gray-200'
+                                }`}
+                        >
+                            <Bell
+                                size={20}
+                                className={isNotifOpen ? 'text-indigo-600' : 'text-gray-500 group-hover:text-indigo-600'}
+                            />
+                            <span className="absolute top-2.5 right-2.5 w-2 h-2 bg-red-500 rounded-full border-2 border-white" />
+                        </button>
+                        <NotificationModal
+                            isOpen={isNotifOpen}
+                            onClose={() => setIsNotifOpen(false)}
+                        />
+                    </div>
+
+                    {/* Profile */}
+                    <div className="flex items-center gap-3 cursor-pointer group">
+                        <div className="text-right hidden sm:block">
+                            <p className="text-sm font-bold text-gray-900 leading-tight group-hover:text-indigo-600 transition-colors">
+                                {instructor.fullName}
+                            </p>
+                            <p className="text-[10px] text-gray-400 uppercase tracking-widest font-black mt-0.5">Instructor</p>
+                        </div>
+                        <div className="relative">
+                            <img
+                                src={instructor.avatar}
+                                alt={instructor.fullName}
+                                className="w-11 h-11 rounded-xl border-2 border-transparent group-hover:border-indigo-500 p-0.5 transition-all duration-300"
+                            />
+                            <div className="absolute -bottom-1 -right-1 p-0.5 bg-white rounded-full shadow-sm border border-gray-100">
+                                <ChevronDown size={10} className="text-gray-400 group-hover:text-indigo-600 transition-colors" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </header>
+    );
+};

--- a/frontend-v2/src/components/dashboard/instructor/InstructorDashboardLayout.tsx
+++ b/frontend-v2/src/components/dashboard/instructor/InstructorDashboardLayout.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import React, { useState } from "react";
+import { Sidebar, routeType } from "./Sidebar";
+import { Header } from "./Header";
+import {
+    LayoutDashboard,
+    UserCircle,
+    BookOpen,
+    Calendar
+} from "lucide-react";
+import { usePathname } from "next/navigation";
+
+interface InstructorDashboardLayoutProps {
+    children: React.ReactNode;
+}
+
+export const InstructorDashboardLayout: React.FC<InstructorDashboardLayoutProps> = ({ children }) => {
+    const pathname = usePathname();
+    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+    const routes: routeType[] = [
+        {
+            name: "Overview",
+            icon: LayoutDashboard,
+            route: "/student/dashboard",
+            isActive: pathname === "/student/dashboard",
+        },
+        {
+            name: "Account",
+            icon: UserCircle,
+            route: "/student/dashboard/account",
+            isActive: pathname === "/student/dashboard/account",
+        },
+        {
+            name: "Course Management",
+            icon: BookOpen,
+            route: "/student/dashboard/courses",
+            isActive: pathname.includes("/courses"),
+        },
+        {
+            name: "Sessions",
+            icon: Calendar,
+            route: "/student/dashboard/sessions",
+            isActive: pathname === "/student/dashboard/sessions",
+        },
+    ];
+
+    return (
+        <div className="min-h-screen bg-gray-50/50 flex">
+            {/* Mobile sidebar backdrop */}
+            {isSidebarOpen && (
+                <div
+                    className="fixed inset-0 z-30 bg-black/40 lg:hidden"
+                    onClick={() => setIsSidebarOpen(false)}
+                />
+            )}
+            <Sidebar routes={routes} isOpen={isSidebarOpen} />
+            <div className="flex-1 lg:ml-64 flex flex-col min-h-screen">
+                <Header onMenuToggle={() => setIsSidebarOpen((prev) => !prev)} />
+                <main className="flex-1 p-8">
+                    <div className="max-w-[1400px] mx-auto animate-in fade-in slide-in-from-bottom-4 duration-700">
+                        {children}
+                    </div>
+                </main>
+            </div>
+        </div>
+    );
+};

--- a/frontend-v2/src/components/dashboard/instructor/NotificationModal.tsx
+++ b/frontend-v2/src/components/dashboard/instructor/NotificationModal.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { X, Info, Check } from "lucide-react";
+
+interface Notification {
+    id: string;
+    message: string;
+    time: string;
+    isRead: boolean;
+}
+
+interface NotificationModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+export const NotificationModal: React.FC<NotificationModalProps> = ({
+    isOpen,
+    onClose,
+}) => {
+    if (!isOpen) return null;
+
+    const notifications: Notification[] = [
+        {
+            id: "1",
+            message: "New student enrolled in 'Blockchain Fundamentals'",
+            time: "2 mins ago",
+            isRead: false,
+        },
+        {
+            id: "2",
+            message: "Course update pending for 'React Masterclass'",
+            time: "1 hour ago",
+            isRead: false,
+        },
+        {
+            id: "3",
+            message: "Your monthly report is ready for download",
+            time: "5 hours ago",
+            isRead: true,
+        },
+    ];
+
+    return (
+        <>
+            {/* Backdrop for clicking outside */}
+            <div
+                className="fixed inset-0 z-40 bg-transparent"
+                onClick={onClose}
+            />
+
+            <div className="absolute right-0 mt-2 w-80 bg-white rounded-2xl shadow-2xl border border-gray-200 z-50 overflow-hidden transform transition-all animate-in fade-in slide-in-from-top-2">
+                <div className="flex items-center justify-between p-4 border-b border-gray-100 bg-gray-50/50">
+                    <h3 className="font-semibold text-gray-900">Notifications</h3>
+                    <button
+                        onClick={onClose}
+                        className="p-1 rounded-full hover:bg-gray-200 text-gray-400 transition"
+                    >
+                        <X size={16} />
+                    </button>
+                </div>
+
+                <div className="max-h-[400px] overflow-y-auto">
+                    {notifications.length > 0 ? (
+                        notifications.map((notif) => (
+                            <div
+                                key={notif.id}
+                                className="p-4 border-b border-gray-50 last:border-0 hover:bg-gray-50 transition cursor-pointer group"
+                            >
+                                <div className="flex gap-3">
+                                    <div className="mt-1 w-8 h-8 rounded-full bg-indigo-50 flex items-center justify-center text-indigo-600 flex-shrink-0 group-hover:bg-indigo-100 transition">
+                                        <Info size={16} />
+                                    </div>
+                                    <div className="flex-1">
+                                        <p className="text-sm text-gray-800 leading-snug font-medium">
+                                            {notif.message}
+                                        </p>
+                                        <span className="text-[11px] text-gray-400 mt-1 block">
+                                            {notif.time}
+                                        </span>
+                                    </div>
+                                    {!notif.isRead && (
+                                        <div className="mt-2 w-2 h-2 rounded-full bg-indigo-600 flex-shrink-0" />
+                                    )}
+                                </div>
+                            </div>
+                        ))
+                    ) : (
+                        <div className="py-10 text-center">
+                            <p className="text-sm text-gray-400">No new notifications</p>
+                        </div>
+                    )}
+                </div>
+
+                <div className="p-3 bg-gray-50 text-center border-t border-gray-100">
+                    <button className="flex items-center justify-center gap-2 w-full text-xs font-semibold text-indigo-600 hover:text-indigo-700 transition">
+                        <Check size={14} />
+                        Mark all as read
+                    </button>
+                </div>
+            </div>
+        </>
+    );
+};

--- a/frontend-v2/src/components/dashboard/instructor/Sidebar.tsx
+++ b/frontend-v2/src/components/dashboard/instructor/Sidebar.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import React, { ComponentType } from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+export type routeType = {
+    name: string;
+    icon: ComponentType<{ className?: string }>;
+    route: string;
+    isActive: boolean;
+};
+
+interface SidebarProps {
+    routes: routeType[];
+    isOpen?: boolean;
+}
+
+export const Sidebar: React.FC<SidebarProps> = ({ routes, isOpen }) => {
+    return (
+        <aside className={cn(
+            "fixed left-0 top-0 z-40 h-screen w-64 border-r bg-white transition-transform duration-300 overflow-y-auto lg:translate-x-0",
+            isOpen ? "translate-x-0" : "-translate-x-full"
+        )}>
+            <div className="flex h-full flex-col px-4 py-6">
+                {/* Logo */}
+                <Link href="/" className="mb-10 flex items-center gap-2 px-2">
+                    <div className="w-8 h-8 bg-gradient-to-br from-blue-600 to-indigo-600 rounded-lg flex items-center justify-center">
+                        <span className="text-white font-bold text-lg">C</span>
+                    </div>
+                    <span className="font-bold text-xl text-gray-900">ChainVerse</span>
+                </Link>
+
+                {/* Navigation */}
+                <nav className="flex-1 space-y-2">
+                    {routes.map((route) => (
+                        <Link
+                            key={route.name}
+                            href={route.route}
+                            className={cn(
+                                "flex items-center rounded-xl px-4 py-3 text-sm font-medium transition-all duration-200",
+                                route.isActive
+                                    ? "bg-indigo-50 text-indigo-600"
+                                    : "text-gray-500 hover:bg-gray-50 hover:text-gray-900"
+                            )}
+                        >
+                            <route.icon
+                                className={cn(
+                                    "mr-3 h-5 w-5",
+                                    route.isActive ? "text-indigo-600" : "text-gray-400"
+                                )}
+                            />
+                            {route.name}
+                        </Link>
+                    ))}
+                </nav>
+
+                {/* Bottom Section (Optional) */}
+                <div className="mt-auto pt-6 border-t border-gray-100">
+                    <p className="text-xs text-center text-gray-400">© 2026 ChainVerse</p>
+                </div>
+            </div>
+        </aside>
+    );
+};


### PR DESCRIPTION
closes #185 

## Description  
## Summary
- Add reusable `Sidebar` component with `routeType[]` props (Overview, Account, Course Management, Sessions)
- Add `Header` component with personalized greeting, search bar, wallet address, profile image, and notification bell
- Add `NotificationModal` triggered by bell icon with mock notifications; closes on outside click or bell re-click
- Wire everything in `InstructorDashboardLayout` with mobile sidebar toggle (hamburger button + backdrop overlay)
- Set up `student/dashboard` route with layout and overview page

## Checklist  
- [ x] My code follows the project's coding style.  
- [ x] I have tested these changes locally.  
- [x ] Documentation has been updated where necessary.  
