### PR TITLE
Fix/auth issues 251 253 255 258

### DIFF
--- a/frontend-v2/src/features/auth/hooks/useLogout.ts
+++ b/frontend-v2/src/features/auth/hooks/useLogout.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { authService } from "@/src/features/auth/services/auth.service";
+import { authService } from "../services/auth.service";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/frontend-v2/src/features/auth/pages/LoginPage.tsx
+++ b/frontend-v2/src/features/auth/pages/LoginPage.tsx
@@ -60,10 +60,11 @@ export const LoginPage: React.FC = () => {
 
       {/* Email Field */}
       <div>
-        <label className="block text-sm font-semibold text-gray-700 mb-2">
+        <label htmlFor="email" className="block text-sm font-semibold text-gray-700 mb-2">
           Email Address
         </label>
         <input
+          id="email"
           type="email"
           placeholder="you@example.com"
           className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition ${
@@ -78,11 +79,12 @@ export const LoginPage: React.FC = () => {
 
       {/* Password Field */}
       <div>
-        <label className="block text-sm font-semibold text-gray-700 mb-2">
+        <label htmlFor="password" className="block text-sm font-semibold text-gray-700 mb-2">
           Password
         </label>
         <div className="relative">
           <input
+            id="password"
             type={showPassword ? 'text' : 'password'}
             placeholder="••••••••"
             className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition pr-12 ${

--- a/frontend-v2/src/features/auth/pages/PasswordResetPage.tsx
+++ b/frontend-v2/src/features/auth/pages/PasswordResetPage.tsx
@@ -5,44 +5,77 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { AuthForm } from '../components/AuthForm';
+import { apiClient } from '@/lib/api-client';
 
 const emailSchema = z.object({
-  email: z
-    .string()
-    .min(1, 'Email is required')
-    .email('Please enter a valid email'),
+  email: z.string().min(1, 'Email is required').email('Please enter a valid email'),
 });
 
 const codeSchema = z.object({
-  code: z
-    .string()
-    .min(6, 'Verification code must be 6 digits')
-    .max(6, 'Verification code must be 6 digits'),
+  code: z.string().min(6, 'Code must be 6 digits').max(6, 'Code must be 6 digits'),
 });
+
+const resetSchema = z
+  .object({
+    password: z.string().min(8, 'Password must be at least 8 characters'),
+    confirmPassword: z.string().min(1, 'Please confirm your password'),
+  })
+  .refine((d: { password: string; confirmPassword: string }) => d.password === d.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
 
 type EmailFormData = z.infer<typeof emailSchema>;
 type CodeFormData = z.infer<typeof codeSchema>;
+type ResetFormData = z.infer<typeof resetSchema>;
 
 export const PasswordResetPage: React.FC = () => {
-  const [step, setStep] = useState<'request' | 'verify'>('request');
+  const [step, setStep] = useState<'request' | 'verify' | 'reset'>('request');
   const [submittedEmail, setSubmittedEmail] = useState('');
+  const [verifiedCode, setVerifiedCode] = useState('');
+  const [apiError, setApiError] = useState<string | null>(null);
 
-  const emailForm = useForm<EmailFormData>({
-    resolver: zodResolver(emailSchema),
-  });
+  const emailForm = useForm<EmailFormData>({ resolver: zodResolver(emailSchema) });
+  const codeForm = useForm<CodeFormData>({ resolver: zodResolver(codeSchema) });
+  const resetForm = useForm<ResetFormData>({ resolver: zodResolver(resetSchema) });
 
-  const codeForm = useForm<CodeFormData>({
-    resolver: zodResolver(codeSchema),
-  });
-
-  const onRequestReset = (data: EmailFormData) => {
-    console.log('Password reset requested for:', data.email);
-    setSubmittedEmail(data.email);
-    setStep('verify');
+  const onRequestReset = async (data: EmailFormData) => {
+    setApiError(null);
+    try {
+      await apiClient.post('/api/auth/password-reset/request', { email: data.email });
+      setSubmittedEmail(data.email);
+      setStep('verify');
+    } catch {
+      setApiError('Failed to send reset code. Please try again.');
+    }
   };
 
-  const onVerifyCode = (data: CodeFormData) => {
-    console.log('Verification code submitted:', data.code);
+  const onVerifyCode = async (data: CodeFormData) => {
+    setApiError(null);
+    try {
+      await apiClient.post('/api/auth/password-reset/verify', {
+        email: submittedEmail,
+        code: data.code,
+      });
+      setVerifiedCode(data.code);
+      setStep('reset');
+    } catch {
+      setApiError('Invalid or expired code. Please try again.');
+    }
+  };
+
+  const onResetPassword = async (data: ResetFormData) => {
+    setApiError(null);
+    try {
+      await apiClient.post('/api/auth/password-reset/confirm', {
+        email: submittedEmail,
+        code: verifiedCode,
+        password: data.password,
+      });
+      window.location.href = '/auth/login';
+    } catch {
+      setApiError('Failed to reset password. Please try again.');
+    }
   };
 
   if (step === 'verify') {
@@ -52,12 +85,17 @@ export const PasswordResetPage: React.FC = () => {
         subtitle={`We sent a 6-digit code to ${submittedEmail}`}
         onSubmit={codeForm.handleSubmit(onVerifyCode)}
       >
-        {/* Code Input */}
+        {apiError && (
+          <div role="alert" className="px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm">
+            {apiError}
+          </div>
+        )}
         <div>
-          <label className="block text-sm font-semibold text-gray-700 mb-2">
+          <label htmlFor="code" className="block text-sm font-semibold text-gray-700 mb-2">
             Verification Code
           </label>
           <input
+            id="code"
             type="text"
             placeholder="123456"
             maxLength={6}
@@ -69,39 +107,87 @@ export const PasswordResetPage: React.FC = () => {
             {...codeForm.register('code')}
           />
           {codeForm.formState.errors.code && (
-            <p className="text-red-500 text-sm mt-1">
-              {codeForm.formState.errors.code.message}
-            </p>
+            <p className="text-red-500 text-sm mt-1">{codeForm.formState.errors.code.message}</p>
           )}
         </div>
-
-        {/* Submit */}
         <button
           type="submit"
           disabled={codeForm.formState.isSubmitting}
           className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
         >
           {codeForm.formState.isSubmitting ? (
-            <>
-              <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-              Verifying...
-            </>
-          ) : (
-            'Verify Code'
-          )}
+            <><div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />Verifying...</>
+          ) : 'Verify Code'}
         </button>
-
-        {/* Back */}
         <p className="text-center text-gray-600 text-sm">
           Didn&apos;t receive a code?{' '}
-          <button
-            type="button"
-            onClick={() => setStep('request')}
-            className="text-blue-600 hover:text-blue-700 font-semibold"
-          >
+          <button type="button" onClick={() => setStep('request')} className="text-blue-600 hover:text-blue-700 font-semibold">
             Try again
           </button>
         </p>
+      </AuthForm>
+    );
+  }
+
+  if (step === 'reset') {
+    return (
+      <AuthForm
+        title="Set New Password"
+        subtitle="Choose a strong password for your account"
+        onSubmit={resetForm.handleSubmit(onResetPassword)}
+      >
+        {apiError && (
+          <div role="alert" className="px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm">
+            {apiError}
+          </div>
+        )}
+        <div>
+          <label htmlFor="password" className="block text-sm font-semibold text-gray-700 mb-2">
+            New Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            placeholder="••••••••"
+            className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition ${
+              resetForm.formState.errors.password
+                ? 'border-red-300 focus-visible:ring-red-500'
+                : 'border-gray-300 focus-visible:ring-blue-500'
+            }`}
+            {...resetForm.register('password')}
+          />
+          {resetForm.formState.errors.password && (
+            <p className="text-red-500 text-sm mt-1">{resetForm.formState.errors.password.message}</p>
+          )}
+        </div>
+        <div>
+          <label htmlFor="confirmPassword" className="block text-sm font-semibold text-gray-700 mb-2">
+            Confirm Password
+          </label>
+          <input
+            id="confirmPassword"
+            type="password"
+            placeholder="••••••••"
+            className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition ${
+              resetForm.formState.errors.confirmPassword
+                ? 'border-red-300 focus-visible:ring-red-500'
+                : 'border-gray-300 focus-visible:ring-blue-500'
+            }`}
+            {...resetForm.register('confirmPassword')}
+          />
+          {resetForm.formState.errors.confirmPassword && (
+            <p className="text-red-500 text-sm mt-1">{resetForm.formState.errors.confirmPassword.message}</p>
+          )}
+        </div>
+        <button
+          type="submit"
+          disabled={resetForm.formState.isSubmitting}
+          className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+        >
+          {resetForm.formState.isSubmitting ? (
+            <><div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />Resetting...</>
+          ) : 'Reset Password'}
+        </button>
       </AuthForm>
     );
   }
@@ -112,12 +198,17 @@ export const PasswordResetPage: React.FC = () => {
       subtitle="Enter your email and we'll send you a reset code"
       onSubmit={emailForm.handleSubmit(onRequestReset)}
     >
-      {/* Email */}
+      {apiError && (
+        <div role="alert" className="px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm">
+          {apiError}
+        </div>
+      )}
       <div>
-        <label className="block text-sm font-semibold text-gray-700 mb-2">
+        <label htmlFor="email" className="block text-sm font-semibold text-gray-700 mb-2">
           Email Address
         </label>
         <input
+          id="email"
           type="email"
           placeholder="you@example.com"
           className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition ${
@@ -128,34 +219,21 @@ export const PasswordResetPage: React.FC = () => {
           {...emailForm.register('email')}
         />
         {emailForm.formState.errors.email && (
-          <p className="text-red-500 text-sm mt-1">
-            {emailForm.formState.errors.email.message}
-          </p>
+          <p className="text-red-500 text-sm mt-1">{emailForm.formState.errors.email.message}</p>
         )}
       </div>
-
-      {/* Submit */}
       <button
         type="submit"
         disabled={emailForm.formState.isSubmitting}
         className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
       >
         {emailForm.formState.isSubmitting ? (
-          <>
-            <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-            Sending...
-          </>
-        ) : (
-          'Send Reset Code'
-        )}
+          <><div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />Sending...</>
+        ) : 'Send Reset Code'}
       </button>
-
-      {/* Back to login */}
       <p className="text-center text-gray-600 text-sm">
         Remember your password?{' '}
-        <a href="/auth/login" className="text-blue-600 hover:text-blue-700 font-semibold">
-          Sign in
-        </a>
+        <a href="/auth/login" className="text-blue-600 hover:text-blue-700 font-semibold">Sign in</a>
       </p>
     </AuthForm>
   );

--- a/frontend-v2/src/features/auth/pages/RegisterPage.tsx
+++ b/frontend-v2/src/features/auth/pages/RegisterPage.tsx
@@ -51,10 +51,11 @@ export const RegisterPage: React.FC = () => {
     >
       {/* Full Name */}
       <div>
-        <label className="block text-sm font-semibold text-gray-700 mb-2">
+        <label htmlFor="fullName" className="block text-sm font-semibold text-gray-700 mb-2">
           Full Name
         </label>
         <input
+          id="fullName"
           type="text"
           placeholder="John Doe"
           className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition ${
@@ -71,10 +72,11 @@ export const RegisterPage: React.FC = () => {
 
       {/* Email */}
       <div>
-        <label className="block text-sm font-semibold text-gray-700 mb-2">
+        <label htmlFor="email" className="block text-sm font-semibold text-gray-700 mb-2">
           Email Address
         </label>
         <input
+          id="email"
           type="email"
           placeholder="you@example.com"
           className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition ${
@@ -91,11 +93,12 @@ export const RegisterPage: React.FC = () => {
 
       {/* Password */}
       <div>
-        <label className="block text-sm font-semibold text-gray-700 mb-2">
+        <label htmlFor="password" className="block text-sm font-semibold text-gray-700 mb-2">
           Password
         </label>
         <div className="relative">
           <input
+            id="password"
             type={showPassword ? 'text' : 'password'}
             placeholder="••••••••"
             className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition pr-12 ${
@@ -120,11 +123,12 @@ export const RegisterPage: React.FC = () => {
 
       {/* Confirm Password */}
       <div>
-        <label className="block text-sm font-semibold text-gray-700 mb-2">
+        <label htmlFor="confirmPassword" className="block text-sm font-semibold text-gray-700 mb-2">
           Confirm Password
         </label>
         <div className="relative">
           <input
+            id="confirmPassword"
             type={showConfirm ? 'text' : 'password'}
             placeholder="••••••••"
             className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition pr-12 ${

--- a/frontend-v2/src/features/auth/services/auth.service.ts
+++ b/frontend-v2/src/features/auth/services/auth.service.ts
@@ -40,10 +40,13 @@ export const authService = {
     return data;
   },
 
-  getToken: (): string | null => localStorage.getItem(TOKEN_KEY),
+  // Token lives in an HttpOnly cookie — not readable from JS.
+  // Use isAuthenticated() to check session presence via middleware.
+  getToken: (): string | null => null,
 
-  setToken: (token: string): void => {
-    localStorage.setItem(TOKEN_KEY, token);
+  setToken: (_token: string): void => {
+    // Token is stored in HttpOnly cookie set by the server at /api/auth/login.
+    // Do NOT write to localStorage — vulnerable to XSS.
   },
 
   /**
@@ -73,5 +76,7 @@ export const authService = {
     return token ? { Authorization: `Bearer ${token}` } : {};
   },
 
-  isAuthenticated: (): boolean => !!authService.getToken(),
+  // Session validity is enforced by middleware.ts checking the 'session' cookie.
+  // Client-side check reads the non-HttpOnly session indicator cookie if present.
+  isAuthenticated: (): boolean => document.cookie.split(';').some(c => c.trim().startsWith('session=')),
 };


### PR DESCRIPTION
## Summary

This PR fixes four bugs in the auth module covering security, accessibility, a broken password reset flow, and a wrong import path.

---

### #258 — Labels missing `htmlFor` (accessibility)

All `<label>` elements in `LoginPage`, `RegisterPage`, and `PasswordResetPage` now have `htmlFor` attributes matched to their input `id`s. Screen readers can now correctly associate labels with their inputs.

**Files changed:** `LoginPage.tsx`, `RegisterPage.tsx`, `PasswordResetPage.tsx`

---

### #253 — JWT stored in localStorage (XSS vulnerability)

Removed `localStorage.setItem` from `authService.setToken`. The client no longer writes the JWT to localStorage. Authentication state is now determined by the presence of the `session` HttpOnly cookie set by the server, consistent with how `middleware.ts` already guards protected routes.

**Files changed:** `auth.service.ts`

---

### #251 — Password reset verify step had no API call

`PasswordResetPage` previously only `console.log`'d the verification code. It now has a proper 3-step flow:
1. **Request** — POSTs email to `/api/auth/password-reset/request`
2. **Verify** — POSTs code to `/api/auth/password-reset/verify`, advances on success
3. **Reset** — POSTs new password to `/api/auth/password-reset/confirm`, redirects to login

All steps include error handling and user-facing error messages.

**Files changed:** `PasswordResetPage.tsx`

---

### #255 — useLogout imports authService from wrong path

Changed the import in `useLogout.ts` from `@/src/features/auth/services/auth.service` to the relative path `../services/auth.service`, consistent with `useSession.ts` and every other intra-feature import in the codebase.

**Files changed:** `useLogout.ts`

---

Closes #251
Closes #253
Closes #255
Closes #258
