### PR TITLE
fix(auth): resolve issues #252 #254 #256 #257

### DIFF
--- a/frontend-v2/src/features/auth/pages/LoginPage.tsx
+++ b/frontend-v2/src/features/auth/pages/LoginPage.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { AuthForm } from '../components/AuthForm';
 import { authService } from '../services/auth.service';
 
@@ -107,9 +108,9 @@ export const LoginPage: React.FC = () => {
 
       {/* Forgot Password */}
       <div className="text-right">
-        <a href="/auth/reset-password" className="text-blue-600 hover:text-blue-700 text-sm font-medium">
+        <Link href="/auth/reset-password" className="text-blue-600 hover:text-blue-700 text-sm font-medium">
           Forgot password?
-        </a>
+        </Link>
       </div>
 
       {/* Submit Button */}
@@ -131,9 +132,9 @@ export const LoginPage: React.FC = () => {
       {/* Sign Up Link */}
       <p className="text-center text-gray-600 text-sm">
         Don&apos;t have an account?{' '}
-        <a href="/auth/register" className="text-blue-600 hover:text-blue-700 font-semibold">
+        <Link href="/auth/register" className="text-blue-600 hover:text-blue-700 font-semibold">
           Sign up
-        </a>
+        </Link>
       </p>
     </AuthForm>
   );

--- a/frontend-v2/src/features/auth/pages/PasswordResetPage.tsx
+++ b/frontend-v2/src/features/auth/pages/PasswordResetPage.tsx
@@ -4,6 +4,8 @@ import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { AuthForm } from '../components/AuthForm';
 import { apiClient } from '@/lib/api-client';
 
@@ -64,6 +66,8 @@ export const PasswordResetPage: React.FC = () => {
     }
   };
 
+  const router = useRouter();
+
   const onResetPassword = async (data: ResetFormData) => {
     setApiError(null);
     try {
@@ -72,7 +76,7 @@ export const PasswordResetPage: React.FC = () => {
         code: verifiedCode,
         password: data.password,
       });
-      window.location.href = '/auth/login';
+      router.push('/auth/login');
     } catch {
       setApiError('Failed to reset password. Please try again.');
     }
@@ -233,7 +237,7 @@ export const PasswordResetPage: React.FC = () => {
       </button>
       <p className="text-center text-gray-600 text-sm">
         Remember your password?{' '}
-        <a href="/auth/login" className="text-blue-600 hover:text-blue-700 font-semibold">Sign in</a>
+        <Link href="/auth/login" className="text-blue-600 hover:text-blue-700 font-semibold">Sign in</Link>
       </p>
     </AuthForm>
   );

--- a/frontend-v2/src/features/auth/pages/RegisterPage.tsx
+++ b/frontend-v2/src/features/auth/pages/RegisterPage.tsx
@@ -5,6 +5,7 @@ import { Eye, EyeOff } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import Link from 'next/link';
 import { AuthForm } from '../components/AuthForm';
 
 const registerSchema = z
@@ -170,9 +171,9 @@ export const RegisterPage: React.FC = () => {
       {/* Login Link */}
       <p className="text-center text-gray-600 text-sm">
         Already have an account?{' '}
-        <a href="/auth/login" className="text-blue-600 hover:text-blue-700 font-semibold">
+        <Link href="/auth/login" className="text-blue-600 hover:text-blue-700 font-semibold">
           Sign in
-        </a>
+        </Link>
       </p>
     </AuthForm>
   );

--- a/frontend-v2/src/features/auth/services/auth.service.ts
+++ b/frontend-v2/src/features/auth/services/auth.service.ts
@@ -1,82 +1,54 @@
 import { apiClient } from '@/lib/api-client';
 import type { AuthResponse, LoginPayload, RegisterPayload } from '../types/auth.types';
 
-// ─── Constants ────────────────────────────────────────────────────────────────
-
-/** All storage keys written during auth — must all be cleared on logout. */
-const TOKEN_KEY    = 'auth_token';
-const USER_KEY     = 'auth_user';
-const SESSION_KEYS = [TOKEN_KEY, USER_KEY] as const;
-
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
- * Clears every auth-related key from both localStorage and sessionStorage.
- * O(k) where k = SESSION_KEYS.length (constant → O(1) in practice).
+ * Clears the JS-accessible session indicator cookie on logout.
+ * The HttpOnly auth cookie is cleared server-side via /api/auth/logout.
  */
-function clearAllStorage(): void {
-  for (const key of SESSION_KEYS) {
-    localStorage.removeItem(key);
-    sessionStorage.removeItem(key);
-  }
-
-  // Clear the HttpOnly-equivalent cookie if the server sets one
-  // (document.cookie write only clears the JS-accessible variant)
-  document.cookie = `${TOKEN_KEY}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Strict`;
+function clearSessionCookie(): void {
+  document.cookie = 'session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Strict';
 }
 
 // ─── Service ──────────────────────────────────────────────────────────────────
 
 export const authService = {
   login: async (payload: LoginPayload): Promise<AuthResponse> => {
-    const data = await apiClient.post<AuthResponse>('/api/auth/login', payload);
-    authService.setToken(data.token);
-    return data;
+    // Server sets the HttpOnly 'session' cookie in the response.
+    return apiClient.post<AuthResponse>('/api/auth/login', payload);
   },
 
   register: async (payload: RegisterPayload): Promise<AuthResponse> => {
-    const data = await apiClient.post<AuthResponse>('/api/auth/register', payload);
-    authService.setToken(data.token);
-    return data;
+    // Server sets the HttpOnly 'session' cookie in the response.
+    return apiClient.post<AuthResponse>('/api/auth/register', payload);
   },
 
   // Token lives in an HttpOnly cookie — not readable from JS.
-  // Use isAuthenticated() to check session presence via middleware.
+  // Components that need to make authenticated API calls should use
+  // apiClient directly; the cookie is sent automatically with each request.
   getToken: (): string | null => null,
-
-  setToken: (_token: string): void => {
-    // Token is stored in HttpOnly cookie set by the server at /api/auth/login.
-    // Do NOT write to localStorage — vulnerable to XSS.
-  },
 
   /**
    * logout
    *
    * 1. Fires a server-side token revocation request (fire-and-forget).
    *    A network failure NEVER blocks the client-side logout.
-   * 2. Clears all auth keys from localStorage, sessionStorage, and cookies.
-   *
-   * Time:  O(1) — constant key-count clear.
-   * Space: O(1) — no additional allocations.
+   * 2. Clears the JS-accessible session indicator cookie.
+   *    The HttpOnly auth cookie is expired by the server response.
    */
   logout: async (): Promise<void> => {
-    // Fire-and-forget: server revokes the token (invalidates refresh token etc.)
-    // We don't await or throw — client logout must always complete.
     try {
       await apiClient.post('/api/auth/logout', {});
     } catch {
-      // Intentionally swallowed — client state is cleared regardless
+      // Intentionally swallowed — client logout must always complete.
     } finally {
-      clearAllStorage();
+      clearSessionCookie();
     }
   },
 
-  getAuthHeaders: (): Record<string, string> => {
-    const token = authService.getToken();
-    return token ? { Authorization: `Bearer ${token}` } : {};
-  },
-
-  // Session validity is enforced by middleware.ts checking the 'session' cookie.
-  // Client-side check reads the non-HttpOnly session indicator cookie if present.
-  isAuthenticated: (): boolean => document.cookie.split(';').some(c => c.trim().startsWith('session=')),
+  // Session validity is enforced by middleware.ts checking the HttpOnly 'session' cookie.
+  // This client-side check reads the non-HttpOnly session indicator cookie if present.
+  isAuthenticated: (): boolean =>
+    document.cookie.split(';').some((c) => c.trim().startsWith('session=')),
 };

--- a/frontend-v2/src/hooks/index.ts
+++ b/frontend-v2/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useLocalStorage';
 export * from './useWindowSize';
 export * from './useDebounce';
+export * from './useSession';

--- a/frontend-v2/src/hooks/useSession.ts
+++ b/frontend-v2/src/hooks/useSession.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { authService } from '@/features/auth/services/auth.service';
+
+interface SessionState {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+}
+
+/**
+ * useSession
+ *
+ * Returns auth status only. The raw token is intentionally not exposed —
+ * components that need to make API calls should use apiClient directly,
+ * which sends the HttpOnly session cookie automatically.
+ *
+ * #256 Fix: removed `token` from return value to avoid widening attack surface.
+ */
+export function useSession(): SessionState {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    setIsAuthenticated(authService.isAuthenticated());
+    setIsLoading(false);
+  }, []);
+
+  return { isAuthenticated, isLoading };
+}

--- a/frontend-v2/src/middleware.ts
+++ b/frontend-v2/src/middleware.ts
@@ -1,7 +1,11 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
-const PUBLIC_PATHS = new Set<string>(['/login', '/signup', '/forgot-password'])
+const PUBLIC_PATHS = new Set<string>([
+  '/auth/login',
+  '/auth/register',
+  '/auth/reset-password',
+])
 
 export function middleware(request: NextRequest) {
 	const { pathname } = request.nextUrl
@@ -10,14 +14,17 @@ export function middleware(request: NextRequest) {
 		return NextResponse.next()
 	}
 
-	if (PUBLIC_PATHS.has(pathname)) {
+	// Allow all /auth/* routes through without a session check
+	if (pathname.startsWith('/auth/') || PUBLIC_PATHS.has(pathname)) {
 		return NextResponse.next()
 	}
 
+	// Strategy (a): server sets an HttpOnly 'session' cookie on login.
+	// Middleware reads it here — never touches localStorage.
 	const hasSession = request.cookies.has('session')
 	if (!hasSession) {
 		const url = request.nextUrl.clone()
-		url.pathname = '/login'
+		url.pathname = '/auth/login'
 		url.searchParams.set('redirect', pathname)
 		return NextResponse.redirect(url)
 	}


### PR DESCRIPTION
#252 - PasswordResetPage: replace window.location.href with router.push
  after successful password reset to use client-side navigation

#254 - middleware: align PUBLIC_PATHS with actual /auth/* routes
  (/auth/login, /auth/register, /auth/reset-password) and redirect
  unauthenticated users to /auth/login instead of /login.
  auth.service: remove stale localStorage/sessionStorage clearing —
  tokens are HttpOnly cookies set by the server, never written to storage.
  Removed dead setToken/getAuthHeaders stubs to eliminate confusion.

#256 - Add useSession hook that exposes only { isAuthenticated, isLoading }.
  Raw token is intentionally omitted — components needing API calls should
  use apiClient directly (cookie sent automatically). Exported from hooks/index.

#257 - Replace all <a href> tags with Next.js <Link> in LoginPage,
  RegisterPage, and PasswordResetPage to enable client-side navigation
  and avoid full page reloads.

## Description  
<!-- Provide a brief summary of the changes in this PR. Explain what was modified and why. -->  

## Related Issues  
<!-- Link any related issues using `Closes #issue_number` or `Fixes #issue_number`. This helps track bugs and feature requests. -->  

## Changes Made  
- [ ] <!-- List key changes made in this PR. Use bullet points for clarity. -->  

## How to Test  
<!-- Explain how a reviewer can test these changes. Provide commands, steps, or expected results if applicable. -->  

## Screenshots (if applicable)  
<!-- If your PR affects the UI, upload screenshots to show the changes visually. -->  

## Checklist  
- [ ] My code follows the project's coding style.  
- [ ] I have tested these changes locally.  
- [ ] Documentation has been updated where necessary.  
this pr closes #252 
closes #254 
closes #256 
closes #257 
