### PR TITLE
fix(courses): API integration, filter logic, empty state, wishlist persistence

### DIFF
--- a/frontend-v2/src/context/WishlistContext.tsx
+++ b/frontend-v2/src/context/WishlistContext.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+
+interface WishlistContextValue {
+  wishlist: Set<string>;
+  toggle: (courseId: string) => void;
+  isWishlisted: (courseId: string) => boolean;
+}
+
+const WishlistContext = createContext<WishlistContextValue | null>(null);
+
+const STORAGE_KEY = 'cv_wishlist';
+
+export function WishlistProvider({ children }: { children: React.ReactNode }) {
+  const [wishlist, setWishlist] = useState<Set<string>>(() => {
+    if (typeof window === 'undefined') return new Set();
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored ? new Set<string>(JSON.parse(stored)) : new Set();
+    } catch {
+      return new Set();
+    }
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...wishlist]));
+  }, [wishlist]);
+
+  const toggle = useCallback((courseId: string) => {
+    setWishlist((prev) => {
+      const next = new Set(prev);
+      if (next.has(courseId)) {
+        next.delete(courseId);
+      } else {
+        next.add(courseId);
+      }
+      return next;
+    });
+  }, []);
+
+  const isWishlisted = useCallback(
+    (courseId: string) => wishlist.has(courseId),
+    [wishlist]
+  );
+
+  return (
+    <WishlistContext.Provider value={{ wishlist, toggle, isWishlisted }}>
+      {children}
+    </WishlistContext.Provider>
+  );
+}
+
+export function useWishlist(): WishlistContextValue {
+  const ctx = useContext(WishlistContext);
+  if (!ctx) throw new Error('useWishlist must be used within WishlistProvider');
+  return ctx;
+}

--- a/frontend-v2/src/features/courses/components/CourseList.tsx
+++ b/frontend-v2/src/features/courses/components/CourseList.tsx
@@ -2,17 +2,18 @@
 
 import React from 'react';
 import { Star } from 'lucide-react';
+import { EmptyState } from '@/shared/components/ui/EmptyState';
 
 interface CourseItem {
   id: string;
   title: string;
-  instructor: string;
-  category: string;
-  level: string;
-  price: number;
-  rating: number;
-  students: number;
-  image: string;
+  instructor?: string;
+  category?: string;
+  level?: string;
+  price?: number;
+  rating?: number;
+  students?: number;
+  image?: string;
 }
 
 interface CourseListProps {
@@ -20,6 +21,15 @@ interface CourseListProps {
 }
 
 export const CourseList: React.FC<CourseListProps> = ({ courses }) => {
+  if (courses.length === 0) {
+    return (
+      <EmptyState
+        title="No courses found"
+        description="Try adjusting your filters."
+      />
+    );
+  }
+
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       {courses.map((course) => (
@@ -27,12 +37,10 @@ export const CourseList: React.FC<CourseListProps> = ({ courses }) => {
           key={course.id}
           className="bg-white rounded-xl border border-gray-200 overflow-hidden hover:shadow-md transition"
         >
-          {/* Image */}
           <div className="h-40 bg-gradient-to-br from-blue-400 to-indigo-600 flex items-center justify-center">
             <span className="text-white text-sm font-semibold">{course.category}</span>
           </div>
 
-          {/* Content */}
           <div className="p-5 space-y-3">
             <div className="flex items-center justify-between">
               <span className={`text-xs font-semibold px-2.5 py-1 rounded-full ${
@@ -45,7 +53,7 @@ export const CourseList: React.FC<CourseListProps> = ({ courses }) => {
                 {course.level}
               </span>
               <span className="text-lg font-bold text-indigo-600">
-                {course.price > 0 ? `$${course.price.toFixed(2)}` : 'Free'}
+                {(course.price ?? 0) > 0 ? `$${(course.price as number).toFixed(2)}` : 'Free'}
               </span>
             </div>
 

--- a/frontend-v2/src/features/courses/components/courseCard.tsx
+++ b/frontend-v2/src/features/courses/components/courseCard.tsx
@@ -4,7 +4,7 @@ import { Star, Heart, ShoppingCart } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useWishlist } from '@/src/context/WishlistContext';
 
 interface CourseCardProps {
   id: number;
@@ -20,6 +20,7 @@ interface CourseCardProps {
 }
 
 export function CourseCard({
+  id,
   title,
   rating,
   description,
@@ -33,7 +34,8 @@ export function CourseCard({
 }: CourseCardProps & {
   onAddToCart?: () => void;
 }) {
-  const [isWishlisted, setIsWishlisted] = useState(false);
+  const { toggle, isWishlisted } = useWishlist();
+  const wishlisted = isWishlisted(String(id));
 
   const renderStars = () => {
     const stars = [];
@@ -71,12 +73,12 @@ export function CourseCard({
         )}
         {/* Wishlist Button */}
         <button
-          onClick={() => setIsWishlisted(!isWishlisted)}
+          onClick={() => toggle(String(id))}
           className="absolute top-3 right-3 bg-white rounded-full p-2 shadow-md hover:shadow-lg transition-all hover:scale-110"
         >
           <Heart
             size={18}
-            className={isWishlisted ? 'fill-red-500 text-red-500' : 'text-gray-400'}
+            className={wishlisted ? 'fill-red-500 text-red-500' : 'text-gray-400'}
           />
         </button>
         {/* Category Badge */}

--- a/frontend-v2/src/features/courses/pages/CoursesPage.tsx
+++ b/frontend-v2/src/features/courses/pages/CoursesPage.tsx
@@ -30,10 +30,13 @@ export const CoursesPage = () => {
       course.title.toLowerCase().includes(searchQuery.toLowerCase());
     const matchesCategory =
       selectedCategories.length === 0 ||
-      selectedCategories.includes(course.instructorId ?? ''); // adjust field when API returns category
+      selectedCategories.includes(course.category ?? '');
+    const matchesLevel =
+      selectedLevel === 'All' ||
+      (course.level ?? '').toLowerCase() === selectedLevel.toLowerCase();
     const matchesPrice =
       course.price == null || course.price <= priceRange;
-    return matchesSearch && matchesCategory && matchesPrice;
+    return matchesSearch && matchesCategory && matchesLevel && matchesPrice;
   });
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / COURSES_PER_PAGE));

--- a/frontend-v2/src/features/courses/types/index.ts
+++ b/frontend-v2/src/features/courses/types/index.ts
@@ -4,6 +4,9 @@ export type Course = {
   description?: string;
   thumbnailUrl?: string;
   instructorId?: string;
+  instructor?: string;
+  category?: string;
+  level?: string;
   rating?: number;
   studentCount?: number;
   price?: number;

--- a/frontend-v2/src/shared/utils/providers.tsx
+++ b/frontend-v2/src/shared/utils/providers.tsx
@@ -3,6 +3,7 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/lib/query-client";
 import { ToastProvider } from "@/src/context/ToastContext";
+import { WishlistProvider } from "@/src/context/WishlistContext";
 
 export default function Providers({
   children,
@@ -11,7 +12,9 @@ export default function Providers({
 }) {
   return (
     <QueryClientProvider client={queryClient}>
-      <ToastProvider>{children}</ToastProvider>
+      <ToastProvider>
+        <WishlistProvider>{children}</WishlistProvider>
+      </ToastProvider>
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary

Fixes four issues in the Courses feature.

### #261 — CoursesPage uses real API (already done)
`CoursesPage` was already wired to `useCourses` hook which calls `courseService.list()`. Confirmed no mock data in use.

### #262 — Filter logic applied to courses
- Added `selectedLevel` check to the `filtered` computation in `CoursesPage`
- Fixed `selectedCategories` filter to use `course.category` (was incorrectly using `course.instructorId`)
- Extended `Course` type with `level`, `category`, and `instructor` fields

### #263 — Empty state when no courses match filters
- `CourseList` now renders `<EmptyState title="No courses found" description="Try adjusting your filters." />` when `courses.length === 0`

### #264 — Wishlist state persisted across navigation
- Created `WishlistContext` (`src/context/WishlistContext.tsx`) with `toggle` / `isWishlisted` API
- State synced to `localStorage` so it survives navigation and page refreshes
- `CourseCard` now reads from `useWishlist()` instead of local `useState`
- `WishlistProvider` added to the app `Providers` tree

## Files changed
- `src/context/WishlistContext.tsx` — new wishlist context
- `src/features/courses/types/index.ts` — extended `Course` type
- `src/features/courses/pages/CoursesPage.tsx` — level + category filter fix
- `src/features/courses/components/CourseList.tsx` — empty state
- `src/features/courses/components/courseCard.tsx` — wishlist context wiring
- `src/shared/utils/providers.tsx` — WishlistProvider added

Closes #261
Closes #262
Closes #263
Closes #264