### PR TITLE
fix: README, image domains, CSP headers, relocate TwoFactorModal

### DIFF
--- a/frontend-v2/README.md
+++ b/frontend-v2/README.md
@@ -1,36 +1,71 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# ChainVerse Frontend v2
+
+A Next.js 14 application for the ChainVerse learning platform.
+
+## Prerequisites
+
+- Node.js >= 18.x
+- npm >= 9.x
+- Copy `.env.example` to `.env.local` and fill in the required values:
+
+```bash
+cp .env.example .env.local
+```
+
+| Variable | Description |
+|---|---|
+| `NEXT_PUBLIC_API_URL` | Base URL for the backend API |
+| `NEXTAUTH_SECRET` | Secret for NextAuth session signing |
+| `NEXTAUTH_URL` | Canonical URL of the app (e.g. `http://localhost:3000`) |
 
 ## Getting Started
 
-First, run the development server:
-
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) in your browser.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Project Structure
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```
+frontend-v2/
+├── app/              # Next.js App Router pages and layouts
+├── src/
+│   ├── components/   # Reusable UI components
+│   ├── features/     # Feature-scoped modules
+│   ├── store/        # Global state (Zustand)
+│   ├── hooks/        # Custom React hooks
+│   └── shared/       # Shared utilities and types
+├── services/         # API service layer
+├── utils/            # Helper functions and validators
+└── e2e/              # Playwright end-to-end tests
+```
 
-## Learn More
+## Running Tests
 
-To learn more about Next.js, take a look at the following resources:
+Unit tests (Vitest):
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+npm test
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+End-to-end tests (Playwright):
 
-## Deploy on Vercel
+```bash
+npm run test:e2e
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Building for Production
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+npm run build
+npm start
+```
+
+Analyze bundle size:
+
+```bash
+ANALYZE=true npm run build
+```

--- a/frontend-v2/next.config.ts
+++ b/frontend-v2/next.config.ts
@@ -10,10 +10,54 @@ const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
       {
-        protocol: 'https',
-        hostname: 'api.dicebear.com',
+        protocol: "https",
+        hostname: "api.dicebear.com",
+      },
+      {
+        protocol: "https",
+        hostname: "**.cloudinary.com",
+      },
+      {
+        protocol: "https",
+        hostname: "**.amazonaws.com",
+      },
+      {
+        protocol: "https",
+        hostname: "res.cloudinary.com",
+      },
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
       },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "X-DNS-Prefetch-Control", value: "on" },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+          {
+            key: "Content-Security-Policy",
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' blob: data: https:",
+              "font-src 'self'",
+              "connect-src 'self' https:",
+            ].join("; "),
+          },
+        ],
+      },
+    ];
   },
 };
 

--- a/frontend-v2/src/components/auth/TwoFactorModal.tsx
+++ b/frontend-v2/src/components/auth/TwoFactorModal.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Fingerprint } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { cn } from '@/utils/cn';
+
+interface BiometricLoginViewProps {
+  onStartScan: () => void;
+  onSwitchToEmail: () => void;
+  className?: string;
+  isScanning?: boolean;
+}
+
+export function BiometricLoginView({
+  onStartScan,
+  onSwitchToEmail,
+  className,
+  isScanning = false,
+}: BiometricLoginViewProps) {
+  return (
+    <div className={cn('flex flex-col items-center space-y-8 py-8', className)}>
+      <div className="relative">
+        <div className="flex h-20 w-20 items-center justify-center rounded-full bg-teal-100">
+          <Fingerprint className="h-10 w-10 text-[#0D9488]" />
+        </div>
+        <div className="absolute -inset-2 rounded-full border-2 border-transparent">
+          <div className="absolute left-0 top-0 h-6 w-6 border-l-2 border-t-2 border-[#0D9488] rounded-tl-full" />
+          <div className="absolute right-0 top-0 h-6 w-6 border-r-2 border-t-2 border-[#0D9488] rounded-tr-full" />
+          <div className="absolute bottom-0 left-0 h-6 w-6 border-b-2 border-l-2 border-[#0D9488] rounded-bl-full" />
+          <div className="absolute bottom-0 right-0 h-6 w-6 border-b-2 border-r-2 border-[#0D9488] rounded-br-full" />
+        </div>
+      </div>
+
+      <div className="text-center space-y-4">
+        <h3 className="text-xl font-semibold text-gray-900">
+          Biometric Authentication
+        </h3>
+        <p className="text-gray-600 max-w-sm">
+          Place your finger on the scanner or look at the camera to sign in
+        </p>
+      </div>
+
+      <Button
+        variant="default"
+        size="lg"
+        onClick={onStartScan}
+        disabled={isScanning}
+        className="px-8"
+      >
+        {isScanning ? 'Scanning...' : 'Start Scan'}
+      </Button>
+
+      <button
+        onClick={onSwitchToEmail}
+        className="text-sm text-gray-900 hover:text-gray-700 focus:outline-none focus:underline"
+      >
+        Having trouble? Use email login
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #344, closes #342, closes #341, closes #339

- **#344** Added a proper `README.md` for `frontend-v2` covering prerequisites, env vars, getting started, project structure, tests, and production build.
- **#342** Added `remotePatterns` in `next.config.ts` for Cloudinary, S3, Unsplash, and dicebear to prevent runtime `next/image` errors.
- **#341** Added `headers()` to `next.config.ts` with CSP, `X-Frame-Options`, `X-Content-Type-Options`, HSTS, and `Referrer-Policy`.
- **#339** Moved `TwoFactorModal.tsx` from `src/store/settings/` to `src/components/auth/` where UI components belong.