### PR TITLE
fix: student registration endpoint changed to POST /student/register

### DIFF
--- a/frontend-v2/src/features/auth/services/student-register.service.ts
+++ b/frontend-v2/src/features/auth/services/student-register.service.ts
@@ -1,0 +1,18 @@
+import { apiClient } from '../../../lib/api-client';
+
+export type RegisterStudentDto = {
+  name: string;
+  email: string;
+  password: string;
+};
+
+export type RegisterStudentResponse = {
+  id: string;
+  email: string;
+  message: string;
+};
+
+export const studentRegisterService = {
+  register: (dto: RegisterStudentDto) =>
+    apiClient.post<RegisterStudentResponse>('/student/register', dto),
+};


### PR DESCRIPTION
## Summary
- Add `student-register.service.ts` calling `POST /student/register` (RESTful convention)
- Replaces the non-standard `/student/create` path

Closes #434