### PR TITLE
fix: student forgot-password endpoint renamed to POST /student/forgot-password

### DIFF
--- a/frontend-v2/src/features/auth/services/student-forgot-password.service.ts
+++ b/frontend-v2/src/features/auth/services/student-forgot-password.service.ts
@@ -1,0 +1,14 @@
+import { apiClient } from '../../../lib/api-client';
+
+export type ForgotPasswordDto = {
+  email: string;
+};
+
+export type ForgotPasswordResponse = {
+  message: string;
+};
+
+export const studentForgotPasswordService = {
+  forgotPassword: (dto: ForgotPasswordDto) =>
+    apiClient.post<ForgotPasswordResponse>('/student/forgot-password', dto),
+};


### PR DESCRIPTION
## Summary
- Add `student-forgot-password.service.ts` calling `POST /student/forgot-password`
- Fixes inconsistent naming (`forget/password` → `forgot-password`)

Closes #435