### PR TITLE
fix: student reset-password endpoint renamed to POST /student/reset-password

### DIFF
--- a/frontend-v2/src/features/auth/services/student-reset-password.service.ts
+++ b/frontend-v2/src/features/auth/services/student-reset-password.service.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '../../../lib/api-client';
+
+export type ResetPasswordDto = {
+  token: string;
+  newPassword: string;
+};
+
+export type ResetPasswordResponse = {
+  message: string;
+};
+
+export const studentResetPasswordService = {
+  resetPassword: (dto: ResetPasswordDto) =>
+    apiClient.post<ResetPasswordResponse>('/student/reset-password', dto),
+};


### PR DESCRIPTION
## Summary
- Add `student-reset-password.service.ts` calling `POST /student/reset-password`
- Removes the nested slash convention (`reset/password` → `reset-password`)

Closes #436