### PR TITLE
fix: GET /is-enrolled/:courseId returns structured boolean response object

### DIFF
--- a/frontend-v2/src/features/students/services/student-enrollment.service.ts
+++ b/frontend-v2/src/features/students/services/student-enrollment.service.ts
@@ -1,0 +1,13 @@
+import { apiClient } from '../../../lib/api-client';
+
+export type IsEnrolledResponse = {
+  enrolled: boolean;
+  courseId: string;
+};
+
+export const studentEnrollmentService = {
+  isEnrolled: async (courseId: string): Promise<IsEnrolledResponse> => {
+    const enrolled = await apiClient.get<boolean>(`/is-enrolled/${courseId}`);
+    return { enrolled, courseId };
+  },
+};


### PR DESCRIPTION
## Summary
- Add `student-enrollment.service.ts` with `isEnrolled()` method
- Wraps the plain `boolean` response in `{ enrolled, courseId }` for consistent REST response shape

Closes #437