### PR TITLE
fix: MongooseModule reads MONGO_URI via ConfigService

### DIFF
--- a/mockup-backend/src/app.module.ts
+++ b/mockup-backend/src/app.module.ts
@@ -1,11 +1,16 @@
 import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 
 @Module({
   imports: [
-    ConfigModule.forRoot({
-      isGlobal: true,
+    ConfigModule.forRoot({ isGlobal: true }),
+    MongooseModule.forRootAsync({
+      useFactory: (config: ConfigService) => ({
+        uri: config.get<string>('MONGO_URI'),
+      }),
+      inject: [ConfigService],
     }),
     ThrottlerModule.forRootAsync({
       imports: [ConfigModule],


### PR DESCRIPTION
## Summary
- Add `MongooseModule.forRootAsync` to `mockup-backend/src/app.module.ts`
- Uses `ConfigService.get('MONGO_URI')` so the correct env var is used and goes through the validated config system
- Removes reliance on `process.env.MONGODB_URI` (which was always `undefined` in production, causing fallback to localhost)

Closes #402