### PR TITLE
fix: add RolesGuard to GET /notifications — admin-only access

### DIFF
--- a/mockup-backend/src/notification.controller.ts
+++ b/mockup-backend/src/notification.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { RolesGuard } from './guards/roles.guard';
+import { Roles } from './decorators/roles.decorator';
+
+@Controller('notifications')
+@UseGuards(JwtAuthGuard)
+export class NotificationController {
+  /**
+   * Admin-only: returns all notifications from all users.
+   * Requires ADMIN role — prevents authenticated non-admin users
+   * from reading other users' notifications.
+   */
+  @Get()
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  findAll() {
+    return [];
+  }
+
+  /**
+   * Returns notifications belonging to the specified user only.
+   * Safe for authenticated students to call for their own userId.
+   */
+  @Get(':userId')
+  findByUserId(@Param('userId') userId: string) {
+    return { userId, notifications: [] };
+  }
+}


### PR DESCRIPTION
## Summary
- Add `mockup-backend/src/notification.controller.ts` with `@UseGuards(RolesGuard)` and `@Roles('admin')` on the `findAll` route
- Prevents any authenticated (non-admin) user from reading all users' notifications
- User-specific `GET /notifications/:userId` remains accessible to authenticated users

Closes #403