### PR TITLE
fix: resolve CI failures - import paths and syntax errors

### DIFF
--- a/frontend-v2/src/features/auth/services/__tests__/auth.service.test.ts
+++ b/frontend-v2/src/features/auth/services/__tests__/auth.service.test.ts
@@ -1,13 +1,13 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { authService } from '../auth.service';
 
-vi.mock('@/lib/api-client', () => ({
+vi.mock('@/src/lib/api-client', () => ({
   apiClient: {
     post: vi.fn(),
   },
 }));
 
-import { apiClient } from '@/lib/api-client';
+import { apiClient } from '@/src/lib/api-client';
 
 const mockUser = {
   id: '1',

--- a/frontend-v2/src/features/auth/services/auth.service.ts
+++ b/frontend-v2/src/features/auth/services/auth.service.ts
@@ -1,4 +1,4 @@
-import { apiClient } from '@/lib/api-client';
+import { apiClient } from '@/src/lib/api-client';
 import type { AuthResponse, LoginPayload, RegisterPayload } from '../types/auth.types';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/frontend-v2/src/features/courses/components/CourseCardSkeleton.tsx
+++ b/frontend-v2/src/features/courses/components/CourseCardSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Card } from "@/shared/components/ui/Card";
+import { Card } from "@/src/shared/components/ui/Card";
 
 export const CourseCardSkeleton = () => {
   return (

--- a/frontend-v2/src/features/students/services/student.service.ts
+++ b/frontend-v2/src/features/students/services/student.service.ts
@@ -20,6 +20,7 @@ export type StudentPayload = {
   avatarUrl?: string;
 };
 
+export const studentService = {
   list: (page = 1, pageSize = 10) =>
     apiClient.get<StudentListResponse>(
       `/students?page=${page}&pageSize=${pageSize}`

--- a/frontend-v2/test/api/api.test.ts
+++ b/frontend-v2/test/api/api.test.ts
@@ -10,6 +10,7 @@ describe('API Integration Tests', () => {
 
   it('should fetch data successfully', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
       json: async () => ({ data: [1, 2, 3] }),
     } as Response);
 

--- a/frontend-v2/test/auth/auth.e2e.test.ts
+++ b/frontend-v2/test/auth/auth.e2e.test.ts
@@ -1,11 +1,11 @@
 ﻿import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { authService } from '@/src/features/auth/services/auth.service';
 
-vi.mock('@/lib/api-client', () => ({
+vi.mock('@/src/lib/api-client', () => ({
   apiClient: { post: vi.fn() },
 }));
 
-import { apiClient } from '@/lib/api-client';
+import { apiClient } from '@/src/lib/api-client';
 
 const mockResponse = {
   user: { id: '1', email: 'student@test.com', firstName: 'A', lastName: 'B', role: 'student' as const },


### PR DESCRIPTION
## Summary

Fixes all CI failures by correcting broken import paths and a syntax error in `frontend-v2`.

## Changes

| File | Fix |
|------|-----|
| `src/features/students/services/student.service.ts` | Added missing `export const studentService = {` (syntax error) |
| `src/features/courses/components/CourseCardSkeleton.tsx` | Fixed import `@/shared/...` → `@/src/shared/...` |
| `src/features/auth/services/auth.service.ts` | Fixed import `@/lib/api-client` → `@/src/lib/api-client` |
| `src/features/auth/services/__tests__/auth.service.test.ts` | Fixed mock path `@/lib/api-client` → `@/src/lib/api-client` |
| `test/auth/auth.e2e.test.ts` | Fixed mock path `@/lib/api-client` → `@/src/lib/api-client` |
| `test/api/api.test.ts` | Added missing `ok: true` in fetch mock response |

## Testing

All 16 test suites pass (60 tests) after these fixes.

Closes #423
Closes #424
Closes #425
Closes #426