### PR TITLE
fix(#441): replace N+1 findById loop with single $in query in getMyCourses

### DIFF
--- a/mockup-backend/src/app.module.ts
+++ b/mockup-backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { CourseRatingsFeedbackModule } from './course-ratings-feedback/course-ra
 import { AdminAuthModule } from './admin-auth/admin-auth.module';
 import { TutorCourseModule } from './tutor-course/tutor-course.module';
 import { AdminCourseModule } from './admin-course/admin-course.module';
+import { StudentEnrollmentModule } from './student-enrollment/student-enrollment.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { AdminCourseModule } from './admin-course/admin-course.module';
     AdminAuthModule,
     TutorCourseModule,
     AdminCourseModule,
+    StudentEnrollmentModule,
   ],
 })
 export class AppModule {}

--- a/mockup-backend/src/student-enrollment/schemas/enrollment.schema.ts
+++ b/mockup-backend/src/student-enrollment/schemas/enrollment.schema.ts
@@ -1,0 +1,32 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+export type EnrollmentDocument = Enrollment & Document;
+
+export type EnrollmentStatus = 'active' | 'completed' | 'dropped';
+
+@Schema({ timestamps: true })
+export class Enrollment {
+  @Prop({ required: true, index: true })
+  studentId: string;
+
+  @Prop({ type: Types.ObjectId, required: true, index: true })
+  courseId: Types.ObjectId;
+
+  @Prop({ required: true, default: Date.now })
+  enrolledAt: Date;
+
+  @Prop({ required: true, enum: ['active', 'completed', 'dropped'], default: 'active' })
+  status: EnrollmentStatus;
+
+  @Prop({ required: true, min: 0, max: 100, default: 0 })
+  progress: number;
+
+  @Prop({ default: null })
+  completedAt: Date | null;
+}
+
+export const EnrollmentSchema = SchemaFactory.createForClass(Enrollment);
+
+// Compound unique index — a student can only enroll in a course once
+EnrollmentSchema.index({ studentId: 1, courseId: 1 }, { unique: true });

--- a/mockup-backend/src/student-enrollment/student-enrollment.controller.ts
+++ b/mockup-backend/src/student-enrollment/student-enrollment.controller.ts
@@ -1,0 +1,34 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+} from '@nestjs/common';
+import { StudentEnrollmentService } from './student-enrollment.service';
+
+@Controller('students/:studentId/enrollments')
+export class StudentEnrollmentController {
+  constructor(private readonly enrollmentService: StudentEnrollmentService) {}
+
+  @Post(':courseId')
+  enroll(
+    @Param('studentId') studentId: string,
+    @Param('courseId') courseId: string,
+  ) {
+    return this.enrollmentService.enroll(studentId, courseId);
+  }
+
+  @Get()
+  getMyCourses(@Param('studentId') studentId: string) {
+    return this.enrollmentService.getMyCourses(studentId);
+  }
+
+  @Delete(':courseId')
+  unenroll(
+    @Param('studentId') studentId: string,
+    @Param('courseId') courseId: string,
+  ) {
+    return this.enrollmentService.unenroll(studentId, courseId);
+  }
+}

--- a/mockup-backend/src/student-enrollment/student-enrollment.module.ts
+++ b/mockup-backend/src/student-enrollment/student-enrollment.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Enrollment, EnrollmentSchema } from './schemas/enrollment.schema';
+import { StudentEnrollmentService } from './student-enrollment.service';
+import { StudentEnrollmentController } from './student-enrollment.controller';
+import { CourseSchema } from '../schemas/course.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Enrollment.name, schema: EnrollmentSchema },
+      { name: 'Course', schema: CourseSchema },
+    ]),
+  ],
+  providers: [StudentEnrollmentService],
+  controllers: [StudentEnrollmentController],
+  exports: [StudentEnrollmentService],
+})
+export class StudentEnrollmentModule {}

--- a/mockup-backend/src/student-enrollment/student-enrollment.service.ts
+++ b/mockup-backend/src/student-enrollment/student-enrollment.service.ts
@@ -1,0 +1,132 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import {
+  Enrollment,
+  EnrollmentDocument,
+} from './schemas/enrollment.schema';
+
+export interface EnrolledCourseDto {
+  enrollmentId: string;
+  enrolledAt: Date;
+  status: string;
+  progress: number;
+  completedAt: Date | null;
+  course: Record<string, unknown> | null;
+}
+
+@Injectable()
+export class StudentEnrollmentService {
+  constructor(
+    @InjectModel(Enrollment.name)
+    private readonly enrollmentModel: Model<EnrollmentDocument>,
+    @InjectModel('Course')
+    private readonly courseModel: Model<any>,
+  ) {}
+
+  /**
+   * Enroll a student in a course.
+   * Throws ConflictException if already enrolled.
+   */
+  async enroll(studentId: string, courseId: string): Promise<EnrollmentDocument> {
+    const course = await this.courseModel
+      .findById(new Types.ObjectId(courseId))
+      .lean()
+      .exec();
+
+    if (!course) {
+      throw new NotFoundException(`Course ${courseId} not found`);
+    }
+
+    const existing = await this.enrollmentModel
+      .findOne({ studentId, courseId: new Types.ObjectId(courseId) })
+      .lean()
+      .exec();
+
+    if (existing) {
+      throw new ConflictException('Student is already enrolled in this course');
+    }
+
+    const [enrollment] = await Promise.all([
+      this.enrollmentModel.create({
+        studentId,
+        courseId: new Types.ObjectId(courseId),
+        enrolledAt: new Date(),
+      }),
+      this.courseModel
+        .findByIdAndUpdate(courseId, { $inc: { totalEnrollments: 1 } })
+        .exec(),
+    ]);
+
+    return enrollment;
+  }
+
+  /**
+   * Get all courses a student is enrolled in.
+   *
+   * Replaces the previous N+1 pattern (one findById per enrollment) with
+   * two total queries:
+   *   1. Find all enrollments for the student          — O(1) DB round-trip
+   *   2. $in query to fetch all courses at once        — O(1) DB round-trip
+   *
+   * Then builds a Map<courseId, course> for O(1) per-lookup assembly.
+   *
+   * Time complexity:  O(n) — n = number of enrollments
+   * Space complexity: O(n) — courseMap holds at most n entries
+   */
+  async getMyCourses(studentId: string): Promise<EnrolledCourseDto[]> {
+    // Query 1: all enrollments for this student
+    const enrollments = await this.enrollmentModel
+      .find({ studentId })
+      .lean()
+      .exec();
+
+    if (enrollments.length === 0) {
+      return [];
+    }
+
+    // Extract courseIds — O(n)
+    const courseIds = enrollments.map((e) => e.courseId);
+
+    // Query 2: single $in to fetch every course in one round-trip
+    const courses = await this.courseModel
+      .find({ _id: { $in: courseIds } })
+      .lean()
+      .exec();
+
+    // Build lookup Map for O(1) access per enrollment — O(n)
+    const courseMap = new Map<string, Record<string, unknown>>(
+      courses.map((c) => [c._id.toString(), c as Record<string, unknown>]),
+    );
+
+    // Assemble response — O(n)
+    return enrollments.map((enrollment) => ({
+      enrollmentId: enrollment._id.toString(),
+      enrolledAt: enrollment.enrolledAt,
+      status: enrollment.status,
+      progress: enrollment.progress,
+      completedAt: enrollment.completedAt,
+      course: courseMap.get(enrollment.courseId.toString()) ?? null,
+    }));
+  }
+
+  /**
+   * Drop (soft-delete) a student's enrollment in a course.
+   */
+  async unenroll(studentId: string, courseId: string): Promise<void> {
+    const enrollment = await this.enrollmentModel
+      .findOne({ studentId, courseId: new Types.ObjectId(courseId) })
+      .exec();
+
+    if (!enrollment) {
+      throw new NotFoundException('Enrollment not found');
+    }
+
+    enrollment.status = 'dropped';
+    await enrollment.save();
+  }
+}


### PR DESCRIPTION
## Summary

- Closes #441
- `getMyCourses()` previously issued one `findById` DB call per enrolled course (N+1 problem). With 100 enrolled courses that was 101 queries.
- Replaced with exactly **2 DB queries** regardless of enrollment count: one to fetch the student's enrollments, one `$in` query to fetch all courses at once.
- A `Map<courseId, course>` is built for O(1) per-item lookup during response assembly.

## Complexity

| | Before | After |
|---|---|---|
| DB queries | N + 1 | **2** |
| Time | O(n) sequential round-trips | O(n) |
| Space | O(n) | O(n) |

## Files Changed

- `src/student-enrollment/schemas/enrollment.schema.ts` — Mongoose schema with compound unique index on `(studentId, courseId)`
- `src/student-enrollment/student-enrollment.service.ts` — core fix; `getMyCourses()`, `enroll()`, `unenroll()`
- `src/student-enrollment/student-enrollment.controller.ts` — REST endpoints
- `src/student-enrollment/student-enrollment.module.ts` — NestJS module
- `src/app.module.ts` — registers `StudentEnrollmentModule`

## Test plan

- [ ] `GET /students/:studentId/enrollments` returns all enrolled courses with a single `$in` query (verify via DB query logs)
- [ ] `POST /students/:studentId/enrollments/:courseId` enrolls student and increments `totalEnrollments`
- [ ] Duplicate enrollment attempt returns `409 Conflict`
- [ ] `DELETE /students/:studentId/enrollments/:courseId` sets status to `dropped`
- [ ] Empty enrollment list returns `[]` without hitting the course collection