### PR TITLE
fix: add confirmation modal to CourseForm delete button (#607)

### DIFF
--- a/frontend-v2/src/features/instructors/components/CourseForm.tsx
+++ b/frontend-v2/src/features/instructors/components/CourseForm.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { Modal } from '@/src/shared/components/ui/Modal';
 
 const courseSchema = z.object({
   title: z.string().min(1, 'Title is required').min(3, 'Title must be at least 3 characters'),
@@ -34,6 +35,8 @@ export const CourseForm: React.FC<CourseFormProps> = ({
   isEditing = false,
   loading = false,
 }) => {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
   const {
     register,
     handleSubmit,
@@ -158,11 +161,7 @@ export const CourseForm: React.FC<CourseFormProps> = ({
             </button>
             <button
               type="button"
-              onClick={() => {
-                if (window.confirm('Are you sure you want to delete this course? This action cannot be undone.')) {
-                  onDelete?.();
-                }
-              }}
+              onClick={() => setShowDeleteConfirm(true)}
               disabled={loading}
               className="px-6 py-3 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 transition disabled:opacity-50 disabled:cursor-not-allowed"
             >
@@ -192,6 +191,30 @@ export const CourseForm: React.FC<CourseFormProps> = ({
           </>
         )}
       </div>
+
+      <Modal
+        isOpen={showDeleteConfirm}
+        onClose={() => setShowDeleteConfirm(false)}
+        title="Delete Course"
+      >
+        <p className="text-gray-600 mb-6">Are you sure you want to delete this course? This action cannot be undone.</p>
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={() => setShowDeleteConfirm(false)}
+            className="px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition font-medium"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => { setShowDeleteConfirm(false); onDelete?.(); }}
+            className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition font-medium"
+          >
+            Delete
+          </button>
+        </div>
+      </Modal>
     </form>
   );
 };

--- a/frontend-v2/src/features/instructors/components/__tests__/CourseForm.test.tsx
+++ b/frontend-v2/src/features/instructors/components/__tests__/CourseForm.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { CourseForm } from '../CourseForm';
+
+const noop = () => {};
+
+describe('CourseForm — delete confirmation', () => {
+  it('does not show the confirm modal initially', () => {
+    render(<CourseForm isEditing onSubmit={noop} onDelete={noop} />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('opens the confirmation modal when Delete is clicked', () => {
+    render(<CourseForm isEditing onSubmit={noop} onDelete={noop} />);
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText(/are you sure you want to delete this course/i)).toBeTruthy();
+  });
+
+  it('closes the modal without calling onDelete when Cancel is clicked', () => {
+    const onDelete = vi.fn();
+    render(<CourseForm isEditing onSubmit={noop} onDelete={onDelete} />);
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('calls onDelete and closes modal when Delete is confirmed', async () => {
+    const onDelete = vi.fn();
+    render(<CourseForm isEditing onSubmit={noop} onDelete={onDelete} />);
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    // click the Delete button inside the modal
+    const modalDeleteBtn = screen.getAllByRole('button', { name: /^delete$/i }).find(
+      (btn) => btn.closest('[role="dialog"]')
+    );
+    fireEvent.click(modalDeleteBtn!);
+    await waitFor(() => expect(onDelete).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('does not render Delete button when isEditing is false', () => {
+    render(<CourseForm isEditing={false} onSubmit={noop} />);
+    expect(screen.queryByRole('button', { name: /^delete$/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
Replace window.confirm with a proper Modal dialog to prevent accidental course deletion. Adds Cancel/Delete actions with accessible role=dialog.

- Add showDeleteConfirm state to CourseForm
- Import and use shared Modal component for delete confirmation
- Add 5 tests covering the confirmation flow

## Description  
<!-- Provide a brief summary of the changes in this PR. Explain what was modified and why. -->  

## Related Issues  
<!-- Link any related issues using `Closes #issue_number` or `Fixes #issue_number`. This helps track bugs and feature requests. -->  

## Changes Made  
- [ ] <!-- List key changes made in this PR. Use bullet points for clarity. -->  

## How to Test  
<!-- Explain how a reviewer can test these changes. Provide commands, steps, or expected results if applicable. -->  

## Screenshots (if applicable)  
<!-- If your PR affects the UI, upload screenshots to show the changes visually. -->  

## Checklist  
- [ ] My code follows the project's coding style.  
- [ ] I have tested these changes locally.  
- [ ] Documentation has been updated where necessary.  
closes #607 
