### PR TITLE
fix(courses): pagination doesn't reset when filters change #606

### DIFF
--- a/frontend-v2/src/features/courses/components/CourseList.tsx
+++ b/frontend-v2/src/features/courses/components/CourseList.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { Star } from 'lucide-react';
-import { EmptyState } from '@/shared/components/ui/EmptyState';
+import { EmptyState } from '@/src/shared/components/ui/EmptyState';
 import Link from 'next/link';
 
 interface CourseItem {

--- a/frontend-v2/src/features/courses/hooks/index.ts
+++ b/frontend-v2/src/features/courses/hooks/index.ts
@@ -1,5 +1,6 @@
 export {
   courseKeys,
+  useCourses,
   useCourseList,
   useCourseById,
   useCreateCourse,

--- a/frontend-v2/src/features/courses/hooks/useCourses.ts
+++ b/frontend-v2/src/features/courses/hooks/useCourses.ts
@@ -17,6 +17,23 @@ export const courseKeys = {
 
 // ─── Read hooks ───────────────────────────────────────────────────────────────
 
+/**
+ * Fetches the full course catalogue for client-side filtering.
+ * Used by CoursesPage (fix #606).
+ */
+export function useCourses() {
+  const result = useQuery({
+    queryKey: courseKeys.lists(),
+    queryFn: () => courseService.list(1, 1000),
+  });
+
+  return {
+    courses: result.data?.data ?? [],
+    isLoading: result.isLoading,
+    error: result.error ? (result.error as Error).message : null,
+  };
+}
+
 export function useCourseList(page = 1, pageSize = 10) {
   return useQuery({
     queryKey: courseKeys.list(page, pageSize),

--- a/frontend-v2/src/features/courses/pages/CoursesPage.tsx
+++ b/frontend-v2/src/features/courses/pages/CoursesPage.tsx
@@ -6,7 +6,7 @@ import { CourseFilters } from '../components/CourseFilters';
 import { CourseList } from '../components/CourseList';
 import { CourseCardSkeleton } from '../components/CourseCardSkeleton';
 import { useCourses } from '../hooks';
-import { SectionContainer } from '@/shared/components/layout/SectionContainer';
+import { SectionContainer } from '@/src/shared/components/layout/SectionContainer';
 
 const COURSES_PER_PAGE = 6;
 

--- a/frontend-v2/src/features/courses/pages/__tests__/CoursesPage.test.tsx
+++ b/frontend-v2/src/features/courses/pages/__tests__/CoursesPage.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { CoursesPage } from '../CoursesPage';
+
+// Mock useCourses to return 13 courses (enough for 3 pages at 6/page)
+// Mix levels so filtering by Beginner still leaves multiple pages worth
+const mockCourses = Array.from({ length: 13 }, (_, i) => ({
+  id: String(i + 1),
+  title: `Course ${i + 1}`,
+  category: i % 2 === 0 ? 'Blockchain' : 'DeFi',
+  level: 'Beginner',
+  price: 10,
+}));
+
+vi.mock('../../hooks', () => ({
+  useCourses: () => ({ courses: mockCourses, isLoading: false, error: null }),
+}));
+
+// SectionContainer is a layout wrapper — keep it simple
+vi.mock('@/src/shared/components/layout/SectionContainer', () => ({
+  SectionContainer: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
+describe('CoursesPage — pagination reset on filter change (#606)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders page 1 by default', () => {
+    render(<CoursesPage />);
+    const page1Button = screen.getByRole('button', { name: /go to page 1/i });
+    expect(page1Button).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('resets to page 1 when search query changes', async () => {
+    const user = userEvent.setup();
+    render(<CoursesPage />);
+
+    // Navigate to page 2
+    await user.click(screen.getByRole('button', { name: /go to page 2/i }));
+    expect(screen.getByRole('button', { name: /go to page 2/i })).toHaveAttribute('aria-current', 'page');
+
+    // Change search query — should reset to page 1
+    const searchInput = screen.getByPlaceholderText(/search courses/i);
+    await user.type(searchInput, 'Course');
+
+    expect(screen.getByRole('button', { name: /go to page 1/i })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('resets to page 1 when level filter changes', async () => {
+    const user = userEvent.setup();
+    render(<CoursesPage />);
+
+    // Navigate to page 2
+    await user.click(screen.getByRole('button', { name: /go to page 2/i }));
+    expect(screen.getByRole('button', { name: /go to page 2/i })).toHaveAttribute('aria-current', 'page');
+
+    // Select "Beginner" — keeps all courses visible, should reset to page 1
+    const beginnerRadio = screen.getByRole('radio', { name: 'Beginner' });
+    await user.click(beginnerRadio);
+
+    expect(screen.getByRole('button', { name: /go to page 1/i })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('resets to page 1 when a category filter is toggled', async () => {
+    const user = userEvent.setup();
+    render(<CoursesPage />);
+
+    // Navigate to page 2
+    await user.click(screen.getByRole('button', { name: /go to page 2/i }));
+    expect(screen.getByRole('button', { name: /go to page 2/i })).toHaveAttribute('aria-current', 'page');
+
+    // Toggle a category — should reset to page 1
+    const blockchainCheckbox = screen.getByRole('checkbox', { name: 'Blockchain' });
+    await user.click(blockchainCheckbox);
+
+    expect(screen.getByRole('button', { name: /go to page 1/i })).toHaveAttribute('aria-current', 'page');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #606 — CoursesPage pagination was not resetting to page 1 when filters changed.

## Root Causes
1. **Missing `useCourses` hook** — `CoursesPage` imported `useCourses` from `'../hooks'` but the hook was never defined or exported, causing a runtime crash so pagination never functioned.
2. **Broken import paths** — `CoursesPage.tsx` and `CourseList.tsx` used `@/shared/...` but the `@` alias maps to the project root; the correct path is `@/src/shared/...`.

## Changes
- Added `useCourses()` hook returning `{ courses, isLoading, error }` for client-side filtering
- Exported `useCourses` from `hooks/index.ts`
- Fixed `@/shared/` → `@/src/shared/` in `CoursesPage.tsx` and `CourseList.tsx`
- Added 4 tests verifying `currentPage` resets to 1 on search, level, and category filter changes

## Tests
75/75 passing (19 test files)

closes #606 