### PR TITLE
fix: auth-aware nav, mobile menu auto-close, loading.tsx (#575 #577 #579 #586)

### DIFF
--- a/frontend-v2/src/components/common/Header.tsx
+++ b/frontend-v2/src/components/common/Header.tsx
@@ -1,18 +1,38 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { Menu, X, User, LogOut, Settings } from 'lucide-react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useAuthStore } from '@/src/store/authStore';
 
 export const Header: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const dropdownTriggerRef = useRef<HTMLButtonElement>(null);
+  const pathname = usePathname();
+  const { isAuthenticated, user, clearAuth } = useAuthStore();
 
-  const navLinks = [
-    { label: 'Courses', href: '/courses' },
-    { label: 'Instructors', href: '/instructors' },
-    { label: 'Dashboard', href: '/dashboard' },
-  ];
+  // Auto-close mobile menu on navigation
+  useEffect(() => {
+    setIsMenuOpen(false);
+  }, [pathname]);
+
+  const navLinks = isAuthenticated
+    ? user?.role === 'instructor'
+      ? [
+          { label: 'Instructor Dashboard', href: '/instructors/dashboard' },
+          { label: 'Courses', href: '/courses' },
+        ]
+      : [
+          { label: 'Dashboard', href: '/dashboard' },
+          { label: 'Courses', href: '/courses' },
+          { label: 'Wallet', href: '/wallet' },
+        ]
+    : [
+        { label: 'Courses', href: '/courses' },
+        { label: 'Login', href: '/login' },
+        { label: 'Register', href: '/register' },
+      ];
 
   const closeDropdown = useCallback(() => {
     setIsDropdownOpen(false);
@@ -127,6 +147,7 @@ export const Header: React.FC = () => {
                   <button
                     role="menuitem"
                     aria-label="Log out"
+                    onClick={clearAuth}
                     className="w-full flex items-center gap-3 px-4 py-2 text-red-600 hover:bg-red-50 transition text-sm"
                   >
                     <LogOut size={16} aria-hidden="true" />


### PR DESCRIPTION
## Summary

Resolves four Stellar Wave issues assigned to me.

### Changes

**#579 — Mobile menu stays open after clicking a link**
- Added `usePathname` import from `next/navigation`
- Added `useEffect(() => { setIsMenuOpen(false); }, [pathname])` to auto-close the mobile nav on route changes

**#577 — NavBar shows same links for all users**
- Imported `useAuthStore` into `Header.tsx`
- Unauthenticated users see: Courses, Login, Register
- Students see: Dashboard, Courses, Wallet
- Instructors see: Instructor Dashboard, Courses
- Logout button now calls `clearAuth()`

**#575 — loading.tsx missing from app directory**
- `frontend-v2/app/loading.tsx` already exists and correctly uses the `Spinner` component — no changes needed

**#586 — CartModal uses window.location.href for navigation**
- `CartModal.tsx` already uses `router.push('/courses')` — no changes needed

## Files Changed
- `frontend-v2/src/components/common/Header.tsx`

Closes #575
Closes #577
Closes #579
Closes #586