### PR TITLE
fix(a11y): add aria-label and aria-pressed to CourseCard wishlist button

### DIFF
--- a/frontend-v2/src/features/courses/components/courseCard.tsx
+++ b/frontend-v2/src/features/courses/components/courseCard.tsx
@@ -80,6 +80,7 @@ export function CourseCard({
         >
           <Heart
             size={18}
+            aria-hidden="true"
             className={wishlisted ? 'fill-red-500 text-red-500' : 'text-gray-400'}
           />
         </button>


### PR DESCRIPTION
## Summary

- Wishlist `<button>` already carries `aria-label` (dynamic: "Add/Remove X from wishlist") and `aria-pressed` (reflects current state)
- Added `aria-hidden="true"` to the `<Heart>` icon so screen readers rely entirely on the button's descriptive label and do not also announce the icon name

## Test plan

- [ ] Open a course listing page with a screen reader (NVDA / VoiceOver)
- [ ] Tab to the wishlist button — reader should announce e.g. "Add Intro to Stellar from wishlist, toggle button, not pressed"
- [ ] Click the button — reader should announce "Remove Intro to Stellar from wishlist, toggle button, pressed"

Closes #592