### PR TITLE
[v2][a11y] Fix password toggle buttons aria-label for screen readers

### DIFF
--- a/frontend-v2/src/features/auth/pages/RegisterPage.tsx
+++ b/frontend-v2/src/features/auth/pages/RegisterPage.tsx
@@ -159,7 +159,7 @@ export const RegisterPage: React.FC = () => {
           />
           <button
             type="button"
-            aria-label={showConfirm ? 'Hide password' : 'Show password'}
+            aria-label={showConfirm ? 'Hide confirm password' : 'Show confirm password'}
             onClick={() => setShowConfirm(!showConfirm)}
             className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 rounded"
           >


### PR DESCRIPTION
## Summary

- The confirm password toggle button in `RegisterPage` was using the same `aria-label` as the password toggle (`'Hide password'` / `'Show password'`), making the two buttons indistinguishable to screen readers
- Updated the confirm password toggle to use `'Hide confirm password'` / `'Show confirm password'`

## Test plan

- [ ] Open the register page with a screen reader
- [ ] Tab to the password field's show/hide button — it should announce "Show password" / "Hide password"
- [ ] Tab to the confirm password field's show/hide button — it should announce "Show confirm password" / "Hide confirm password"

Closes #595