### PR TITLE
fix(a11y): add sr-only text for CourseCard star rating

### DIFF
--- a/frontend-v2/src/features/courses/components/courseCard.tsx
+++ b/frontend-v2/src/features/courses/components/courseCard.tsx
@@ -103,7 +103,7 @@ export function CourseCard({
           <p className="text-xs text-gray-600">By {instructor}</p>
           <div className="flex items-center gap-1">
             <div className="flex gap-0.5" aria-hidden="true">{renderStars()}</div>
-            <span className="sr-only">Rating: {rating} out of 5 stars</span>
+            <span className="sr-only">Rated {rating} out of 5 stars</span>
             <span className="text-xs font-semibold text-gray-700 ml-1" aria-hidden="true">{rating}</span>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- The star icon row has `aria-hidden="true"` so screen readers skip the visual SVGs
- A `<span className="sr-only">` announces "Rated X out of 5 stars" to assistive technology
- The numeric rating label next to the stars also carries `aria-hidden="true"` to avoid duplication

## Test plan

- [ ] Navigate a course card with a screen reader
- [ ] Confirm the reader announces "Rated 4.5 out of 5 stars" (or similar) without reading each star icon

Closes #593