### PR TITLE
[v2][a11y] Add aria-label and aria-current to pagination buttons

### DIFF
--- a/frontend-v2/components/ui/Pagination.tsx
+++ b/frontend-v2/components/ui/Pagination.tsx
@@ -13,6 +13,8 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
         <button
           key={i}
           onClick={() => onPageChange(i + 1)}
+          aria-label={`Go to page ${i + 1}`}
+          aria-current={currentPage === i + 1 ? 'page' : undefined}
           className={`px-3 py-1 border rounded ${
             currentPage === i + 1 ? "bg-blue-500 text-white" : ""
           }`}


### PR DESCRIPTION
## Summary

- Pagination page buttons showed only a number with no context for screen readers
- Added `aria-label="Go to page N"` to each page button
- Added `aria-current="page"` to the active page button so screen readers can identify the current page

## Test plan

- [ ] Navigate to a page that uses the Pagination component
- [ ] With a screen reader, focus each page button — it should announce "Go to page N"
- [ ] The active page button should be announced as the current page

Closes #596