### PR TITLE
[v2][a11y] Announce wallet connection state changes to screen readers

### DIFF
--- a/frontend-v2/src/shared/components/ConnectWalletButton.tsx
+++ b/frontend-v2/src/shared/components/ConnectWalletButton.tsx
@@ -5,23 +5,28 @@ import { useWallet } from '@/src/context/WalletContext';
 export function ConnectWalletButton() {
   const { isConnected, publicKey, connect, disconnect } = useWallet();
 
-  if (isConnected && publicKey) {
-    return (
-      <button
-        onClick={disconnect}
-        className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
-      >
-        {publicKey.slice(0, 4)}...{publicKey.slice(-4)}
-      </button>
-    );
-  }
-
   return (
-    <button
-      onClick={connect}
-      className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
-    >
-      Connect Wallet
-    </button>
+    <>
+      <div aria-live="polite" className="sr-only">
+        {isConnected && publicKey
+          ? `Wallet connected: ${publicKey.slice(0, 8)}...`
+          : 'Wallet disconnected'}
+      </div>
+      {isConnected && publicKey ? (
+        <button
+          onClick={disconnect}
+          className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+        >
+          {publicKey.slice(0, 4)}...{publicKey.slice(-4)}
+        </button>
+      ) : (
+        <button
+          onClick={connect}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+        >
+          Connect Wallet
+        </button>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Wallet connect/disconnect events were purely visual with no notification for screen reader users
- Added an `aria-live="polite"` region with `sr-only` class to `ConnectWalletButton` that announces the wallet state on change
- When connected: announces `"Wallet connected: <first 8 chars>..."`
- When disconnected: announces `"Wallet disconnected"`

## Test plan

- [ ] Open a page with the ConnectWalletButton with a screen reader active
- [ ] Connect a wallet — screen reader should announce the connected state
- [ ] Disconnect — screen reader should announce "Wallet disconnected"

Closes #597