### PR TITLE
fix: guard useLocalStorage setValue against SSR window access

### DIFF
--- a/frontend-v2/src/hooks/useLocalStorage.ts
+++ b/frontend-v2/src/hooks/useLocalStorage.ts
@@ -13,7 +13,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
 
   const setValue = (value: T | ((val: T) => T)) => {
     try {
-      const valueToStore = value instanceof Function ? value(storedValue) : value;
+      const valueToStore = typeof value === 'function' ? (value as (val: T) => T)(storedValue) : value;
       setStoredValue(valueToStore);
       if (typeof window !== 'undefined') {
         window.localStorage.setItem(key, JSON.stringify(valueToStore));


### PR DESCRIPTION
## Summary

- Replaces `value instanceof Function` with `typeof value === 'function'` in the `setValue` closure
- `typeof` check is reliable across execution contexts (iframes, vm sandboxes, SSR runtimes) where `instanceof Function` can fail
- Consistent with the existing `typeof window === 'undefined'` SSR guard already present in the `useState` initializer

## Test plan

- [ ] Confirm `useLocalStorage` renders without error in a Next.js SSR pass (server logs show no `ReferenceError`)
- [ ] Confirm functional updater form `setValue(prev => ...)` still works on the client

closes #587