### PR TITLE
fix: remove unused FETCH_DELAY_MS artificial delay from useAnalyticsMetrics

### DIFF
--- a/frontend-v2/src/hooks/useAnalyticsMetrics.ts
+++ b/frontend-v2/src/hooks/useAnalyticsMetrics.ts
@@ -67,8 +67,6 @@ const METRICS_DATA: AnalyticsMetric[] = [
   },
 ];
 
-const FETCH_DELAY_MS = 0; // removed artificial delay — real network latency is sufficient
-
 // ─── Hook ─────────────────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

- `FETCH_DELAY_MS = 1500` was a demo artifact that added a deliberate 1.5-second wait before showing metrics
- The value was zeroed (`= 0`) but the constant was left as dead code, leaving the door open for accidental re-introduction
- This PR deletes the constant entirely; the loading state remains visible during real network latency

## Test plan

- [ ] Confirm the analytics grid renders without the artificial delay in dev
- [ ] Confirm `isLoading` still shows a spinner during the actual (async) data resolution

closes #588