### PR TITLE
fix: correct api-client import path in course.service.ts

### DIFF
--- a/frontend-v2/src/features/courses/services/course.service.ts
+++ b/frontend-v2/src/features/courses/services/course.service.ts
@@ -1,4 +1,4 @@
-import { apiClient } from '@/lib/api-client';
+import { apiClient } from '@/src/lib/api-client';
 import type { Course, CourseListResponse, CoursePayload } from '../types';
 
 export const courseService = {


### PR DESCRIPTION
## Summary

- `course.service.ts` imported `apiClient` from `'@/lib/api-client'`
- The shared client lives at `src/lib/api-client.ts`; with the `@/*` → `./*` alias this resolves to a non-existent `lib/api-client` at the repo root
- Changed to `'@/src/lib/api-client'` (the `@/src/*` alias), consistent with `instructor.service.ts` and `student.service.ts`

This unifies all service files on the single canonical HTTP client and eliminates the diverging code path that the issue flagged.

## Test plan

- [ ] `tsc --noEmit` in `frontend-v2` passes without module-not-found errors
- [ ] Course list / detail API calls succeed in the running app

closes #589