### PR TITLE
fix: add *.log and debug.log to root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .env
 
+# logs
+*.log
+debug.log
+
 # Root-level scratch files from issue #420. Keep these out if they are regenerated locally.
 /aggression.tsx
 /allocation.tsx


### PR DESCRIPTION
## Summary

- Adds `*.log` and `debug.log` to the root `.gitignore` so IDE and npm/yarn debug logs are excluded repo-wide
- `frontend-v1/.gitignore` already excludes `debug.log` locally; this root rule covers the whole monorepo tree
- Existing committed `debug.log` files (if any) should be removed with `git rm --cached`

## Test plan

- [ ] Create a `debug.log` at the repo root and confirm `git status` shows it untracked
- [ ] Confirm no existing source files end in `.log`

closes #590