### PR TITLE
fix: surface API errors on login, add OAuth callback, token refresh, and courses metadata

### DIFF
--- a/frontend-v2/app/(auth)/callback/page.tsx
+++ b/frontend-v2/app/(auth)/callback/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { Suspense, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+const ACCESS_TOKEN_KEY = 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+
+function CallbackHandler() {
+  const router = useRouter();
+  const params = useSearchParams();
+
+  useEffect(() => {
+    const token = params.get('token');
+    const refreshToken = params.get('refreshToken');
+
+    if (token) {
+      localStorage.setItem(ACCESS_TOKEN_KEY, token);
+      if (refreshToken) {
+        localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+      }
+      router.replace('/dashboard');
+    } else {
+      const errorCode = params.get('error') ?? 'oauth_failed';
+      router.replace(`/login?error=${errorCode}`);
+    }
+  }, [router, params]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="text-center">
+        <div className="w-8 h-8 border-2 border-indigo-600 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+        <p className="text-gray-600 text-sm">Signing you in&hellip;</p>
+      </div>
+    </div>
+  );
+}
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center min-h-screen">
+          <p className="text-gray-600">Loading&hellip;</p>
+        </div>
+      }
+    >
+      <CallbackHandler />
+    </Suspense>
+  );
+}

--- a/frontend-v2/app/(main)/courses/page.tsx
+++ b/frontend-v2/app/(main)/courses/page.tsx
@@ -1,4 +1,11 @@
-import { CoursesPage } from "@/features/courses/pages/CoursesPage";
+import type { Metadata } from 'next';
+import { CoursesPage } from '@/features/courses/pages/CoursesPage';
+
+export const metadata: Metadata = {
+  title: 'Explore Courses — ChainVerse',
+  description:
+    'Browse blockchain, DeFi, NFT and smart contract courses. Filter by category, level and price.',
+};
 
 export default function Page() {
   return <CoursesPage />;

--- a/frontend-v2/src/features/auth/pages/LoginPage.tsx
+++ b/frontend-v2/src/features/auth/pages/LoginPage.tsx
@@ -44,8 +44,9 @@ export const LoginPage: React.FC = () => {
         sessionStorage.setItem('session_expires_at', String(Date.now() + response.expiresIn * 1000));
       }
       router.replace('/dashboard');
-    } catch {
-      setApiError('Invalid email or password. Please try again.');
+    } catch (err) {
+      // Surface the actual API error message so users know what went wrong
+      setApiError(err instanceof Error ? err.message : 'Login failed. Please try again.');
     }
   };
 

--- a/frontend-v2/src/features/auth/pages/__tests__/LoginPage.test.tsx
+++ b/frontend-v2/src/features/auth/pages/__tests__/LoginPage.test.tsx
@@ -63,11 +63,22 @@ describe('LoginPage', () => {
   });
 
   it('shows API error message on login failure', async () => {
-    (authService.login as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Invalid credentials'));
+    (authService.login as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Invalid email or password')
+    );
     render(<LoginPage />);
     await userEvent.type(screen.getByLabelText(/email address/i), 'user@test.com');
     await userEvent.type(screen.getByLabelText(/password/i), 'password123');
     await userEvent.click(screen.getByRole('button', { name: /login/i }));
     expect(await screen.findByText(/invalid email or password/i)).toBeInTheDocument();
+  });
+
+  it('shows fallback error message when error has no message', async () => {
+    (authService.login as ReturnType<typeof vi.fn>).mockRejectedValue('unknown');
+    render(<LoginPage />);
+    await userEvent.type(screen.getByLabelText(/email address/i), 'user@test.com');
+    await userEvent.type(screen.getByLabelText(/password/i), 'password123');
+    await userEvent.click(screen.getByRole('button', { name: /login/i }));
+    expect(await screen.findByText(/login failed/i)).toBeInTheDocument();
   });
 });

--- a/frontend-v2/src/features/auth/types/auth.types.ts
+++ b/frontend-v2/src/features/auth/types/auth.types.ts
@@ -15,6 +15,7 @@ export interface User {
 export interface AuthResponse {
   user: User;
   token: string;
+  refreshToken?: string;
   expiresIn: number; // Duration in seconds
 }
 
@@ -47,3 +48,8 @@ export type DecodedToken = {
   iat: number;    // Issued at
   role: string;
 };
+
+export interface RefreshTokenResponse {
+  accessToken: string;
+  expiresIn: number;
+}

--- a/frontend-v2/src/lib/api-client.ts
+++ b/frontend-v2/src/lib/api-client.ts
@@ -2,6 +2,9 @@
  * Centralised HTTP client for all API requests.
  * Reads NEXT_PUBLIC_API_BASE_URL from environment; every service should
  * import from here instead of constructing its own fetch wrapper.
+ *
+ * On 401 responses the client attempts to refresh the access token once
+ * via POST /student/refresh-token before redirecting to /login.
  */
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
@@ -12,17 +15,47 @@ export type RequestOptions = Omit<RequestInit, 'body'> & {
   body?: unknown;
 };
 
-async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
+const REFRESH_TOKEN_KEY = 'refreshToken';
+const ACCESS_TOKEN_KEY = 'accessToken';
+
+/** Attempts to exchange a stored refresh token for a new access token. */
+async function attemptTokenRefresh(): Promise<boolean> {
+  if (typeof window === 'undefined') return false;
+  const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+  if (!refreshToken) return false;
+  try {
+    const res = await fetch(`${BASE_URL}/student/refresh-token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refreshToken }),
+    });
+    if (!res.ok) return false;
+    const data = await res.json() as { accessToken?: string };
+    if (data.accessToken) {
+      localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken);
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+async function request<T>(path: string, options: RequestOptions = {}, isRetry = false): Promise<T> {
   if (!BASE_URL) {
     throw new Error('NEXT_PUBLIC_API_BASE_URL is not configured');
   }
 
   const { token, body, headers: extraHeaders, ...init } = options;
 
+  // Include stored access token when available (falls back to explicit token option)
+  const storedToken = typeof window !== 'undefined' ? localStorage.getItem(ACCESS_TOKEN_KEY) : null;
+  const bearerToken = token ?? storedToken ?? undefined;
+
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     ...(extraHeaders as Record<string, string> | undefined),
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
   };
 
   const controller = new AbortController();
@@ -36,10 +69,20 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
       signal: controller.signal,
     });
 
-    if (response.status === 401) {
-      const { authService } = await import('@/src/features/auth/services/auth.service');
-      authService.logout();
-      window.location.href = '/login?reason=session_expired';
+    if (response.status === 401 && !isRetry) {
+      const refreshed = await attemptTokenRefresh();
+      if (refreshed) {
+        // Retry the original request once with the new access token
+        return request<T>(path, options, true);
+      }
+      // Refresh failed — clear tokens and redirect to login
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem(ACCESS_TOKEN_KEY);
+        localStorage.removeItem(REFRESH_TOKEN_KEY);
+        const { authService } = await import('@/src/features/auth/services/auth.service');
+        authService.logout();
+        window.location.href = '/login?reason=session_expired';
+      }
       throw new Error('Session expired');
     }
 


### PR DESCRIPTION
## Summary

- **#670** — Login form now surfaces the actual API error message from the backend instead of a hardcoded string, giving users actionable feedback. Updated the matching unit test to reflect the new behavior.
- **#674** — Created `app/(auth)/callback/page.tsx` to handle the Google OAuth redirect: extracts `token` and `refreshToken` from query params, stores them in localStorage, and redirects to `/dashboard`. Falls back to `/login?error=oauth_failed`. Uses a Suspense boundary as required by `useSearchParams`.
- **#675** — Extended the centralised `api-client.ts` with automatic token refresh. On a 401 response it posts the stored `refreshToken` to `POST /student/refresh-token`, saves the new `accessToken`, and retries the original request once before falling back to logout + redirect. Added `refreshToken` field to `AuthResponse` type.
- **#677** — Added `generateMetadata` to `app/(main)/courses/page.tsx` so search engines receive a descriptive title and description for the public courses listing.

## Test plan
- [ ] Login with wrong password → meaningful error message displayed
- [ ] Login with correct credentials → redirected to `/dashboard`
- [ ] Visit `/auth/callback?token=X&refreshToken=Y` → tokens stored, redirect to `/dashboard`
- [ ] Visit `/auth/callback` with no token → redirect to `/login?error=oauth_failed`
- [ ] After access token expires (401), verify request is retried with refreshed token
- [ ] Check `<title>` on `/courses` matches "Explore Courses — ChainVerse"
- [ ] `npm test` → all unit tests pass

Closes #670
Closes #674
Closes #675
Closes #677