### PR TITLE
fix: improve 404/error pages, toast API, add TypeScript types and service layer

### DIFF
--- a/frontend-v2/app/error.tsx
+++ b/frontend-v2/app/error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { ErrorFallback } from '@/shared/components/ErrorFallback';
+import { useEffect } from 'react';
+import { ErrorFallback } from '@/src/shared/components/ErrorFallback';
 
 export default function Error({
   error,
@@ -9,5 +10,9 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  useEffect(() => {
+    console.error('Global error boundary caught:', error);
+  }, [error]);
+
   return <ErrorFallback error={error} reset={reset} />;
 }

--- a/frontend-v2/app/not-found.tsx
+++ b/frontend-v2/app/not-found.tsx
@@ -1,13 +1,36 @@
 import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '404 — Page Not Found | ChainVerse',
+};
 
 export default function NotFound() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen gap-4">
-      <h1 className="text-6xl font-bold text-gray-900">404</h1>
-      <p className="text-gray-500">This page doesn&apos;t exist.</p>
-      <Link href="/" className="text-blue-600 hover:underline">
-        Go back home
-      </Link>
+    <div className="flex flex-col items-center justify-center min-h-screen gap-6 px-4 text-center bg-gray-50">
+      <div className="text-8xl font-bold text-indigo-200 select-none" aria-hidden="true">
+        404
+      </div>
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold text-gray-900">Page Not Found</h1>
+        <p className="text-gray-500 max-w-md">
+          The page you are looking for does not exist or may have been moved.
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-3 justify-center">
+        <Link
+          href="/"
+          className="px-6 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+        >
+          Go Home
+        </Link>
+        <Link
+          href="/courses"
+          className="px-6 py-3 border border-gray-300 text-gray-700 bg-white rounded-lg hover:bg-gray-50 transition font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+        >
+          Browse Courses
+        </Link>
+      </div>
     </div>
   );
 }

--- a/frontend-v2/src/context/ToastContext.tsx
+++ b/frontend-v2/src/context/ToastContext.tsx
@@ -9,10 +9,16 @@ interface ToastItem {
   id: string;
   message: string;
   type: ToastType;
+  duration?: number;
 }
 
 interface ToastContextValue {
-  addToast: (message: string, type?: ToastType) => void;
+  addToast: (message: string, type?: ToastType, duration?: number) => void;
+  toast: {
+    success: (message: string, duration?: number) => void;
+    error: (message: string, duration?: number) => void;
+    info: (message: string, duration?: number) => void;
+  };
 }
 
 const ToastContext = createContext<ToastContextValue | null>(null);
@@ -20,10 +26,13 @@ const ToastContext = createContext<ToastContextValue | null>(null);
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
 
-  const addToast = useCallback((message: string, type: ToastType = 'error') => {
-    const id = crypto.randomUUID();
-    setToasts((prev) => [...prev, { id, message, type }]);
-  }, []);
+  const addToast = useCallback(
+    (message: string, type: ToastType = 'error', duration?: number) => {
+      const id = crypto.randomUUID();
+      setToasts((prev) => [...prev, { id, message, type, duration }]);
+    },
+    []
+  );
 
   const removeToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
@@ -34,8 +43,14 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     registerGlobalErrorHandler((message) => addToast(message, 'error'));
   }, [addToast]);
 
+  const toast = {
+    success: (message: string, duration?: number) => addToast(message, 'success', duration),
+    error: (message: string, duration?: number) => addToast(message, 'error', duration),
+    info: (message: string, duration?: number) => addToast(message, 'info', duration),
+  };
+
   return (
-    <ToastContext.Provider value={{ addToast }}>
+    <ToastContext.Provider value={{ addToast, toast }}>
       {children}
       <ToastContainer toasts={toasts} removeToast={removeToast} />
     </ToastContext.Provider>

--- a/frontend-v2/src/services/auth.service.ts
+++ b/frontend-v2/src/services/auth.service.ts
@@ -1,0 +1,43 @@
+import { apiClient } from '@/src/lib/api-client';
+import type { AuthResponse, RefreshTokenResponse } from '@/src/types/api';
+
+export interface LoginDto {
+  email: string;
+  password: string;
+}
+
+export interface RegisterDto {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+}
+
+export interface ForgotPasswordDto {
+  email: string;
+}
+
+export interface ResetPasswordDto {
+  token: string;
+  newPassword: string;
+}
+
+export const authApiService = {
+  login: (dto: LoginDto): Promise<AuthResponse> =>
+    apiClient.post<AuthResponse>('/student/login', dto),
+
+  register: (dto: RegisterDto): Promise<{ message: string }> =>
+    apiClient.post<{ message: string }>('/student/create', dto),
+
+  logout: (): Promise<void> =>
+    apiClient.post<void>('/student/logout', {}),
+
+  refreshToken: (refreshToken: string): Promise<RefreshTokenResponse> =>
+    apiClient.post<RefreshTokenResponse>('/student/refresh-token', { refreshToken }),
+
+  forgotPassword: (dto: ForgotPasswordDto): Promise<{ message: string }> =>
+    apiClient.post<{ message: string }>('/student/forgot-password', dto),
+
+  resetPassword: (dto: ResetPasswordDto): Promise<{ message: string }> =>
+    apiClient.post<{ message: string }>('/student/reset-password', dto),
+};

--- a/frontend-v2/src/services/courses.service.ts
+++ b/frontend-v2/src/services/courses.service.ts
@@ -1,0 +1,29 @@
+import { apiClient } from '@/src/lib/api-client';
+import type { Course, CourseListResponse, PaginationParams } from '@/src/types/api';
+
+export interface CourseSearchParams extends PaginationParams {
+  search?: string;
+  category?: string;
+  level?: string;
+}
+
+export const coursesApiService = {
+  list: (params: CourseSearchParams = {}): Promise<CourseListResponse> => {
+    const query = new URLSearchParams();
+    if (params.page) query.set('page', String(params.page));
+    if (params.limit) query.set('limit', String(params.limit));
+    if (params.search) query.set('search', params.search);
+    if (params.category) query.set('category', params.category);
+    if (params.level) query.set('level', params.level);
+    const qs = query.toString();
+    return apiClient.get<CourseListResponse>(`/courses${qs ? `?${qs}` : ''}`);
+  },
+
+  getById: (id: string): Promise<Course> =>
+    apiClient.get<Course>(`/courses/${id}`),
+
+  search: (query: string, params?: PaginationParams): Promise<CourseListResponse> =>
+    apiClient.get<CourseListResponse>(
+      `/courses?search=${encodeURIComponent(query)}&page=${params?.page ?? 1}&limit=${params?.limit ?? 12}`
+    ),
+};

--- a/frontend-v2/src/services/enrollment.service.ts
+++ b/frontend-v2/src/services/enrollment.service.ts
@@ -1,0 +1,16 @@
+import { apiClient } from '@/src/lib/api-client';
+import type { EnrollmentRecord, EnrollmentListResponse } from '@/src/types/api';
+
+export const enrollmentApiService = {
+  enroll: (courseId: string): Promise<EnrollmentRecord> =>
+    apiClient.post<EnrollmentRecord>('/enrollments', { courseId }),
+
+  myEnrollments: (): Promise<EnrollmentListResponse> =>
+    apiClient.get<EnrollmentListResponse>('/enrollments/my'),
+
+  getProgress: (enrollmentId: string): Promise<EnrollmentRecord> =>
+    apiClient.get<EnrollmentRecord>(`/enrollments/${enrollmentId}`),
+
+  updateProgress: (enrollmentId: string, progress: number): Promise<EnrollmentRecord> =>
+    apiClient.patch<EnrollmentRecord>(`/enrollments/${enrollmentId}/progress`, { progress }),
+};

--- a/frontend-v2/src/services/notifications.service.ts
+++ b/frontend-v2/src/services/notifications.service.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '@/src/lib/api-client';
+import type { Notification, NotificationListResponse, PaginationParams } from '@/src/types/api';
+
+export const notificationsApiService = {
+  list: (params: PaginationParams = {}): Promise<NotificationListResponse> =>
+    apiClient.get<NotificationListResponse>(
+      `/notification?page=${params.page ?? 1}&limit=${params.limit ?? 20}`
+    ),
+
+  markRead: (id: string): Promise<Notification> =>
+    apiClient.patch<Notification>(`/notification/${id}/read`, {}),
+
+  markAllRead: (): Promise<{ message: string }> =>
+    apiClient.patch<{ message: string }>('/notification/read-all', {}),
+};

--- a/frontend-v2/src/services/profile.service.ts
+++ b/frontend-v2/src/services/profile.service.ts
@@ -1,0 +1,13 @@
+import { apiClient } from '@/src/lib/api-client';
+import type { Profile, UpdateProfilePayload, ChangePasswordPayload } from '@/src/types/api';
+
+export const profileApiService = {
+  get: (): Promise<Profile> =>
+    apiClient.get<Profile>('/student/profile'),
+
+  update: (payload: UpdateProfilePayload): Promise<Profile> =>
+    apiClient.patch<Profile>('/student-account-settings/profile', payload),
+
+  changePassword: (payload: ChangePasswordPayload): Promise<{ message: string }> =>
+    apiClient.post<{ message: string }>('/student-account-settings/change-password', payload),
+};

--- a/frontend-v2/src/types/api.ts
+++ b/frontend-v2/src/types/api.ts
@@ -1,0 +1,124 @@
+/**
+ * Typed API response shapes that mirror the ChainVerse backend contracts.
+ * Import these instead of using `any` for API call return types.
+ */
+
+// ─── Auth ─────────────────────────────────────────────────────────────────────
+
+export interface Student {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: 'student';
+  isEmailVerified: boolean;
+  profileImage?: string;
+  bio?: string;
+  avatarUrl?: string;
+}
+
+export interface AuthResponse {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  student: Student;
+}
+
+export interface RefreshTokenResponse {
+  accessToken: string;
+  expiresIn: number;
+}
+
+// ─── Courses ──────────────────────────────────────────────────────────────────
+
+export interface Course {
+  id: string;
+  title: string;
+  description: string;
+  price: number;
+  thumbnailUrl?: string;
+  instructorId: string;
+  instructor?: string;
+  category?: string;
+  level?: string;
+  rating?: number;
+  studentCount?: number;
+}
+
+export interface CourseListResponse {
+  data: Course[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+// ─── Enrollment ───────────────────────────────────────────────────────────────
+
+export interface EnrollmentRecord {
+  id: string;
+  courseId: string;
+  studentId: string;
+  enrolledAt: string;
+  progress: number;
+  completed: boolean;
+}
+
+export interface EnrollmentListResponse {
+  data: EnrollmentRecord[];
+  total: number;
+}
+
+// ─── Profile ──────────────────────────────────────────────────────────────────
+
+export interface Profile {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  bio?: string;
+  avatarUrl?: string;
+  isEmailVerified: boolean;
+}
+
+export interface UpdateProfilePayload {
+  firstName?: string;
+  lastName?: string;
+  bio?: string;
+  avatarUrl?: string;
+}
+
+export interface ChangePasswordPayload {
+  currentPassword: string;
+  newPassword: string;
+}
+
+// ─── Notifications ────────────────────────────────────────────────────────────
+
+export interface Notification {
+  id: string;
+  title: string;
+  message: string;
+  isRead: boolean;
+  type: 'info' | 'success' | 'warning' | 'error';
+  createdAt: string;
+  link?: string;
+}
+
+export interface NotificationListResponse {
+  data: Notification[];
+  total: number;
+  unreadCount: number;
+}
+
+// ─── Pagination ───────────────────────────────────────────────────────────────
+
+export interface PaginationParams {
+  page?: number;
+  limit?: number;
+}
+
+export interface ApiError {
+  message: string;
+  statusCode: number;
+  error?: string;
+}


### PR DESCRIPTION
## Summary

- **#681** — Enhanced `app/not-found.tsx` with branded styling, a descriptive heading/subtext, and dual navigation buttons (Go Home + Browse Courses). Added page-level `Metadata`. Improved `app/error.tsx` to log errors to console for easier debugging.
- **#688** — Extended `ToastContext` with a typed `toast` helper object exposing `toast.success()`, `toast.error()`, and `toast.info()` so components can show notifications without knowing the internal type string. Duration is now configurable per-call.
- **#689** — Created `src/types/api.ts` with typed interfaces for every API response shape: `Student`, `AuthResponse`, `Course`, `CourseListResponse`, `EnrollmentRecord`, `Profile`, `Notification`, `NotificationListResponse`, and supporting payload/param types, eliminating implicit `any` at API call sites.
- **#691** — Created `src/services/` with one file per backend module using the typed interfaces from `#689`:
  - `auth.service.ts` — login, register, logout, refresh, forgot/reset password
  - `courses.service.ts` — list (with search/category/level filters), getById, search
  - `enrollment.service.ts` — enroll, myEnrollments, getProgress, updateProgress
  - `profile.service.ts` — get, update, changePassword
  - `notifications.service.ts` — list, markRead, markAllRead

## Test plan
- [ ] Navigate to a non-existent route → branded 404 page with Home and Browse Courses links
- [ ] Trigger a runtime error → error boundary renders with reset button
- [ ] Import `useToast` and call `toast.success('Done!')` → toast appears top-right
- [ ] TypeScript: `npx tsc --noEmit` passes with no `any`-related errors in new service files
- [ ] Service layer: import `authApiService.login(...)` and verify return type is `AuthResponse`

Closes #681
Closes #688
Closes #689
Closes #691