### PR TITLE
[Bug] Fix global auth state management — persist login across page refreshes

### DIFF
--- a/frontend-v2/src/features/auth/hooks/useLogout.ts
+++ b/frontend-v2/src/features/auth/hooks/useLogout.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { authService } from "../services/auth.service";
+import { useAuthStore } from "@/src/store/authStore";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -43,6 +44,7 @@ export function useLogout(): UseLogoutReturn {
     setError(null);
     try {
       await authService.logout();
+      useAuthStore.getState().logout();
       router.replace(POST_LOGOUT_ROUTE);
     } catch {
       // authService.logout() swallows network errors internally,

--- a/frontend-v2/src/features/auth/pages/LoginPage.tsx
+++ b/frontend-v2/src/features/auth/pages/LoginPage.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { AuthForm } from '../components/AuthForm';
 import { authService } from '../services/auth.service';
+import { useAuthStore } from '@/src/store/authStore';
 
 const loginSchema = z.object({
   email: z
@@ -42,6 +43,9 @@ export const LoginPage: React.FC = () => {
       const response = await authService.login({ email: data.email, password: data.password });
       if (response.expiresIn) {
         sessionStorage.setItem('session_expires_at', String(Date.now() + response.expiresIn * 1000));
+      }
+      if (response.user && response.token) {
+        useAuthStore.getState().login(response.user, response.token);
       }
       router.replace('/dashboard');
     } catch (err) {

--- a/frontend-v2/src/features/auth/pages/__tests__/LoginPage.test.tsx
+++ b/frontend-v2/src/features/auth/pages/__tests__/LoginPage.test.tsx
@@ -15,6 +15,15 @@ vi.mock('../../services/auth.service', () => ({
   },
 }));
 
+vi.mock('@/src/store/authStore', () => ({
+  useAuthStore: {
+    getState: () => ({
+      login: vi.fn(),
+      logout: vi.fn(),
+    }),
+  },
+}));
+
 const mockReplace = vi.fn();
 
 describe('LoginPage', () => {
@@ -25,8 +34,8 @@ describe('LoginPage', () => {
 
   it('renders email and password inputs', () => {
     render(<LoginPage />);
-    expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/you@example\.com/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/••••••••/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /login/i })).toBeInTheDocument();
   });
 
@@ -40,8 +49,8 @@ describe('LoginPage', () => {
   it('calls authService.login with correct values on valid submit', async () => {
     (authService.login as ReturnType<typeof vi.fn>).mockResolvedValue({ expiresIn: 3600 });
     render(<LoginPage />);
-    await userEvent.type(screen.getByLabelText(/email address/i), 'user@test.com');
-    await userEvent.type(screen.getByLabelText(/password/i), 'password123');
+    await userEvent.type(screen.getByPlaceholderText(/you@example\.com/i), 'user@test.com');
+    await userEvent.type(screen.getByPlaceholderText(/••••••••/i), 'password123');
     await userEvent.click(screen.getByRole('button', { name: /login/i }));
     await waitFor(() => {
       expect(authService.login).toHaveBeenCalledWith({
@@ -54,8 +63,8 @@ describe('LoginPage', () => {
   it('redirects to dashboard on success', async () => {
     (authService.login as ReturnType<typeof vi.fn>).mockResolvedValue({ expiresIn: 3600 });
     render(<LoginPage />);
-    await userEvent.type(screen.getByLabelText(/email address/i), 'user@test.com');
-    await userEvent.type(screen.getByLabelText(/password/i), 'password123');
+    await userEvent.type(screen.getByPlaceholderText(/you@example\.com/i), 'user@test.com');
+    await userEvent.type(screen.getByPlaceholderText(/••••••••/i), 'password123');
     await userEvent.click(screen.getByRole('button', { name: /login/i }));
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith('/dashboard');
@@ -67,8 +76,8 @@ describe('LoginPage', () => {
       new Error('Invalid email or password')
     );
     render(<LoginPage />);
-    await userEvent.type(screen.getByLabelText(/email address/i), 'user@test.com');
-    await userEvent.type(screen.getByLabelText(/password/i), 'password123');
+    await userEvent.type(screen.getByPlaceholderText(/you@example\.com/i), 'user@test.com');
+    await userEvent.type(screen.getByPlaceholderText(/••••••••/i), 'password123');
     await userEvent.click(screen.getByRole('button', { name: /login/i }));
     expect(await screen.findByText(/invalid email or password/i)).toBeInTheDocument();
   });
@@ -76,8 +85,8 @@ describe('LoginPage', () => {
   it('shows fallback error message when error has no message', async () => {
     (authService.login as ReturnType<typeof vi.fn>).mockRejectedValue('unknown');
     render(<LoginPage />);
-    await userEvent.type(screen.getByLabelText(/email address/i), 'user@test.com');
-    await userEvent.type(screen.getByLabelText(/password/i), 'password123');
+    await userEvent.type(screen.getByPlaceholderText(/you@example\.com/i), 'user@test.com');
+    await userEvent.type(screen.getByPlaceholderText(/••••••••/i), 'password123');
     await userEvent.click(screen.getByRole('button', { name: /login/i }));
     expect(await screen.findByText(/login failed/i)).toBeInTheDocument();
   });

--- a/frontend-v2/src/features/auth/services/auth.service.ts
+++ b/frontend-v2/src/features/auth/services/auth.service.ts
@@ -8,6 +8,12 @@ const TOKEN_EXPIRY_KEY = 'token_expiry';
 
 // ─── Service ──────────────────────────────────────────────────────────────────
 
+function getSessionCookie(): string | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie.match(/(?:^|;\s*)session=([^;]*)/);
+  return match ? match[1] : null;
+}
+
 export const authService = {
   login: async (payload: LoginPayload): Promise<AuthResponse> => {
     const response = await apiClient.post<AuthResponse>('/api/auth/login', payload);
@@ -39,12 +45,14 @@ export const authService = {
       // Intentionally swallowed — client logout must always complete.
     } finally {
       localStorage.removeItem(TOKEN_EXPIRY_KEY);
+      localStorage.removeItem('auth_user');
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
     }
   },
 
-  // Session validity is enforced by middleware.ts checking the HttpOnly 'session' cookie.
-  // This client-side check reads the non-HttpOnly session indicator cookie if present.
   isAuthenticated: (): boolean => {
+    if (getSessionCookie()) return true;
     const expiry = localStorage.getItem(TOKEN_EXPIRY_KEY);
     if (!expiry) return false;
     return Date.now() < Number(expiry);

--- a/frontend-v2/src/store/authStore.ts
+++ b/frontend-v2/src/store/authStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 interface AuthUser {
   id?: string;
@@ -19,11 +20,50 @@ interface AuthState {
   clearAuth: () => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
-  isAuthenticated: false,
-  user: null,
-  token: null,
-  login: (user, token) => set({ isAuthenticated: true, user, token }),
-  logout: () => set({ isAuthenticated: false, user: null, token: null }),
-  clearAuth: () => set({ isAuthenticated: false, user: null, token: null }),
-}));
+const ACCESS_TOKEN_KEY = 'accessToken';
+const USER_KEY = 'auth_user';
+
+function getStoredUser(): AuthUser | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(USER_KEY);
+    return raw ? (JSON.parse(raw) as AuthUser) : null;
+  } catch {
+    return null;
+  }
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      isAuthenticated: false,
+      user: null,
+      token: null,
+      login: (user, token) => {
+        localStorage.setItem(USER_KEY, JSON.stringify(user));
+        localStorage.setItem(ACCESS_TOKEN_KEY, token);
+        set({ isAuthenticated: true, user, token });
+      },
+      logout: () => {
+        localStorage.removeItem(USER_KEY);
+        localStorage.removeItem(ACCESS_TOKEN_KEY);
+        localStorage.removeItem('refreshToken');
+        localStorage.removeItem('token_expiry');
+        set({ isAuthenticated: false, user: null, token: null });
+      },
+      clearAuth: () => {
+        localStorage.removeItem(USER_KEY);
+        localStorage.removeItem(ACCESS_TOKEN_KEY);
+        set({ isAuthenticated: false, user: null, token: null });
+      },
+    }),
+    {
+      name: 'auth-storage',
+      partialize: (state) => ({
+        isAuthenticated: state.isAuthenticated,
+        user: state.user,
+        token: state.token,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
Closes #684
Closes #685
Closes #686
Closes #687

## Root Cause

The Zustand `authStore` initialized with `isAuthenticated: false` on every page load with no hydration mechanism. While the server-side middleware checked for an HttpOnly `session` cookie, the client-side React state was lost on refresh, causing the UI to flash an unauthenticated state before the middleware redirect could take effect.

## Changes

### Global Auth State Persistence (fixes #684)

**`src/store/authStore.ts`**
- Added `zustand/middleware` persist to automatically save/restore auth state (`isAuthenticated`, `user`, `token`) to/from localStorage
- `login()` now persists `auth_user` and `accessToken` to localStorage immediately
- `logout()` and `clearAuth()` clean up all persisted keys

**`src/features/auth/pages/LoginPage.tsx`**
- After successful login, syncs the Zustand store via `useAuthStore.getState().login(user, token)`
- Ensures the UI reflects authenticated state immediately without waiting for rehydration

**`src/features/auth/services/auth.service.ts`**
- `isAuthenticated()` now checks for the `session` cookie first (matching server-side middleware), falling back to localStorage `token_expiry`
- `logout()` clears all localStorage auth keys (`auth_user`, `accessToken`, `refreshToken`)

**`src/features/auth/hooks/useLogout.ts`**
- Calls `useAuthStore.getState().logout()` after server logout to clear the Zustand store synchronously

### Test Fixes

**`src/features/auth/pages/__tests__/LoginPage.test.tsx`**
- Replaced `getByLabelText(/password/i)` with `getByPlaceholderText` to resolve multiple-element match issue
- Added mock for `useAuthStore` to prevent import errors in test environment
- All 6 LoginPage tests pass

**`src/features/auth/services/__tests__/auth.service.test.ts`**
- `isAuthenticated` tests now pass after implementing cookie-based check

## Test Results

- 87 of 89 tests pass (2 pre-existing failures in `CourseCard.test.tsx` unrelated to this change)
- 8/8 auth service tests pass
- 6/6 LoginPage tests pass