### PR TITLE
feat(app): add API health check + maintenance banner (Closes #693)

### DIFF
--- a/frontend-v2/app/layout.tsx
+++ b/frontend-v2/app/layout.tsx
@@ -34,11 +34,43 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+/**
+ * Probes the backend `/health` endpoint at app start.
+ *
+ * Strips the trailing `/api` or `/api/vN` segment from
+ * `NEXT_PUBLIC_API_BASE_URL` so the probe hits the backend root
+ * (e.g. `http://localhost:3001/health` rather than
+ * `http://localhost:3001/api/v1/health`). The result is cached for
+ * 30 seconds via Next's fetch revalidation so the layout doesn't
+ * hammer the API on every navigation.
+ *
+ * Returns `false` for any failure — missing config, network error,
+ * timeout, or non-2xx — so the banner only ever appears when
+ * something is genuinely wrong.
+ */
+async function isBackendHealthy(): Promise<boolean> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (!apiUrl) return false;
+
+  const baseUrl = apiUrl.replace(/\/api(\/.*)?$/, "");
+  try {
+    const res = await fetch(`${baseUrl}/health`, {
+      next: { revalidate: 30 },
+      signal: AbortSignal.timeout(5_000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const healthy = await isBackendHealthy();
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body
@@ -48,6 +80,17 @@ export default function RootLayout({
           "min-h-screen bg-background font-sans antialiased"
         )}
       >
+        {!healthy && (
+          <div
+            role="status"
+            aria-live="polite"
+            data-testid="maintenance-banner"
+            className="bg-yellow-100 text-yellow-800 text-sm text-center py-2 border-b border-yellow-200"
+          >
+            Backend is starting up. Some features may be temporarily
+            unavailable.
+          </div>
+        )}
         <Providers>{children}</Providers>
       </body>
     </html>


### PR DESCRIPTION
## Description

When the backend is down (Render free-tier cold start, mid-deploy, etc.) the frontend silently failed and users saw broken data with no explanation. This PR adds a top-level maintenance banner that surfaces the outage as soon as the page loads.

---
Closes #693 
---

### How it works

`frontend-v2/app/layout.tsx` (the root App Router layout) is converted to an **async server component** that calls `isBackendHealthy()` before rendering. That helper:

1. Reads `NEXT_PUBLIC_API_BASE_URL`.
2. Strips a trailing `/api` or `/api/vN` segment so the probe hits the backend root (e.g., `http://localhost:3001/health` instead of `http://localhost:3001/api/v1/health`).
3. Fetches `${baseUrl}/health` with `next: { revalidate: 30 }` (30 s cache, so we do not hammer the API) and `AbortSignal.timeout(5_000)` (no build-time hangs in CI).
4. Returns `false` for any failure — missing env, network error, timeout, or non-2xx — so the banner only appears when the backend is genuinely unreachable.

When `healthy === false`, a yellow banner is rendered above `<Providers>`:

```jsx
<div 
  role="status" 
  aria-live="polite" 
  data-testid="maintenance-banner" 
  className="bg-yellow-100 text-yellow-800 text-sm text-center py-2 border-b border-yellow-200"
>
  Backend is starting up. Some features may be temporarily unavailable.
</div>
