### PR TITLE
fix(ui): CourseList grid adapts to ultrawide screens

### DIFF
--- a/frontend-v2/src/features/courses/components/CourseList.tsx
+++ b/frontend-v2/src/features/courses/components/CourseList.tsx
@@ -33,7 +33,7 @@ export const CourseList: React.FC<CourseListProps> = ({ courses }) => {
 
   return (
     <section aria-label="Course listings">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
       {courses.map((course) => (
         <Link
           key={course.id}


### PR DESCRIPTION
## Summary

The `CourseList` grid was hardcoded to 3 columns at the `lg` breakpoint, leaving large empty gutters on ultrawide viewports (1440px+).

## Changes
- Added `xl:grid-cols-4` so a 4th column appears on very wide screens
- Moved the 2-column breakpoint from `md` to `sm` for slightly earlier stacking on narrow tablets

**Before:**
```tsx
<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
```
**After:**
```tsx
<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
```

## Testing
- `sm` (≥640px): 2 columns
- `lg` (≥1024px): 3 columns
- `xl` (≥1280px): 4 columns — no more empty side gutters on ultrawide displays

Closes #720