### PR TITLE
fix(ui): RevenueChart period pills full-width on very small screens

### DIFF
--- a/frontend-v2/src/features/instructors/components/RevenueChart.tsx
+++ b/frontend-v2/src/features/instructors/components/RevenueChart.tsx
@@ -166,7 +166,7 @@ export const RevenueChart: React.FC = () => {
         </div>
 
         {/* Period tabs */}
-        <div className="flex items-center gap-1 bg-gray-50 rounded-xl p-1 border border-gray-100">
+        <div className="flex items-center gap-1 bg-gray-50 rounded-xl p-1 border border-gray-100 w-full sm:w-auto">
           {PERIODS.map(({ label, value }) => (
             <PeriodPill
               key={value}


### PR DESCRIPTION
## Summary

The RevenueChart header uses `flex items-start justify-between mb-6 gap-4 flex-wrap`. On mobile the title and period pill container stack correctly, but the pill container has a fixed border/padding that can be too wide for screens under ~360px, causing awkward wrapping.

## Changes
Added `w-full sm:w-auto` to the period pill container so it takes full width on very small screens and returns to auto width at the `sm` breakpoint.

**Before:**
```tsx
<div className="flex items-center gap-1 bg-gray-50 rounded-xl p-1 border border-gray-100">
```
**After:**
```tsx
<div className="flex items-center gap-1 bg-gray-50 rounded-xl p-1 border border-gray-100 w-full sm:w-auto">
```

## Testing
- <360px: pill container spans full width, pills wrap cleanly inside it
- ≥640px (`sm`): container returns to auto width, sits inline with title as before

Closes #712