### PR TITLE
feat: add mobile responsive filter toggle and improve text truncation…

### DIFF
--- a/frontend-v2/src/features/courses/components/CourseFilters.tsx
+++ b/frontend-v2/src/features/courses/components/CourseFilters.tsx
@@ -31,7 +31,7 @@ export const CourseFilters: React.FC<CourseFiltersProps> = ({
   };
 
   return (
-    <aside className="w-full lg:w-64 flex-shrink-0">
+    <aside className="w-full lg:w-64 flex-shrink-0 overflow-hidden">
       <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-6">
         {/* Category Filter */}
         <div>
@@ -45,7 +45,7 @@ export const CourseFilters: React.FC<CourseFiltersProps> = ({
                   onChange={() => handleCategoryToggle(category)}
                   className="w-4 h-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
                 />
-                <span className="text-sm text-gray-700">{category}</span>
+                <span className="text-sm text-gray-700 truncate">{category}</span>
               </label>
             ))}
           </div>
@@ -64,7 +64,7 @@ export const CourseFilters: React.FC<CourseFiltersProps> = ({
                   onChange={() => onLevelChange(level)}
                   className="w-4 h-4 border-gray-300 text-indigo-600 focus:ring-indigo-500"
                 />
-                <span className="text-sm text-gray-700">{level}</span>
+                <span className="text-sm text-gray-700 truncate">{level}</span>
               </label>
             ))}
           </div>

--- a/frontend-v2/src/features/courses/pages/CoursesPage.tsx
+++ b/frontend-v2/src/features/courses/pages/CoursesPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { Suspense, useState, useEffect } from 'react';
-import { Search } from 'lucide-react';
+import { Search, SlidersHorizontal } from 'lucide-react';
 import { CourseFilters } from '../components/CourseFilters';
 import { CourseList } from '../components/CourseList';
 import { CourseCardSkeleton } from '../components/CourseCardSkeleton';
@@ -16,6 +16,7 @@ function CourseGrid() {
   const [selectedLevel, setSelectedLevel] = useState('All');
   const [priceRange, setPriceRange] = useState(500);
   const [currentPage, setCurrentPage] = useState(1);
+  const [showFilters, setShowFilters] = useState(false);
 
   const { courses, isLoading, error } = useCourses();
 
@@ -68,17 +69,27 @@ function CourseGrid() {
         </div>
       )}
 
-      <div className="flex flex-col lg:flex-row gap-8">
-        <CourseFilters
-          selectedCategories={selectedCategories}
-          selectedLevel={selectedLevel}
-          priceRange={priceRange}
-          onCategoryChange={setSelectedCategories}
-          onLevelChange={setSelectedLevel}
-          onPriceChange={setPriceRange}
-        />
+      <button
+        className="lg:hidden flex items-center gap-2 px-4 py-2 border rounded-lg mb-4"
+        onClick={() => setShowFilters(!showFilters)}
+      >
+        <SlidersHorizontal size={18} />
+        Filters {selectedCategories.length > 0 && `(${selectedCategories.length})`}
+      </button>
 
-        <div className="flex-1">
+      <div className="flex flex-col lg:flex-row gap-8 min-w-0">
+        <div className={`${showFilters ? 'block' : 'hidden'} lg:block`}>
+          <CourseFilters
+            selectedCategories={selectedCategories}
+            selectedLevel={selectedLevel}
+            priceRange={priceRange}
+            onCategoryChange={setSelectedCategories}
+            onLevelChange={setSelectedLevel}
+            onPriceChange={setPriceRange}
+          />
+        </div>
+
+        <div className="flex-1 min-w-0">
           {isLoading ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {Array.from({ length: COURSES_PER_PAGE }).map((_, i) => (

--- a/frontend-v2/src/features/students/pages/StudentDashboardPage.tsx
+++ b/frontend-v2/src/features/students/pages/StudentDashboardPage.tsx
@@ -88,12 +88,12 @@ export const StudentDashboardPage: React.FC = () => {
                     key={index}
                     className="bg-white rounded-lg shadow-sm border border-gray-100 p-6 hover:shadow-md transition"
                   >
-                    <div className="flex items-center justify-between">
+                    <div className="flex items-center justify-between flex-wrap gap-2">
                       <div>
                         <p className="text-gray-600 text-sm font-medium mb-1">{stat.label}</p>
                         <p className="text-3xl font-bold text-gray-900">{stat.value}</p>
                       </div>
-                      <div className={`${STAT_COLORS[index]} p-3 rounded-lg`}>
+                      <div className={`${STAT_COLORS[index]} p-3 rounded-lg flex-shrink-0`}>
                         <Icon size={24} />
                       </div>
                     </div>


### PR DESCRIPTION
## Description

This PR addresses multiple responsive layout bugs across the student dashboard and courses page. It ensures the UI degrades gracefully on smaller screens without text overlap, overflowing components, or inaccessible filters.

### Fixes & Changes

- **Resolves #704 (Mobile Filter Toggle):** Added a mobile toggle button (`SlidersHorizontal`) for the `CourseFilters` on `CoursesPage`. The filters now correctly collapse and expand on smaller devices.
- **Resolves #705 (CourseFilters Overflow):** Added `min-w-0` to the grid container and `overflow-hidden` to the `<aside>` in `CourseFilters`. Labels now appropriately `truncate` instead of breaking the layout on devices under 320px.
- **Resolves #709 (Stats Grid Overlap):** Added `flex-wrap gap-2` to the inner container of the Student Dashboard stat cards and applied `flex-shrink-0` to the icon container, preventing text from overlapping the icons at the 768px (`md`) breakpoint.
- **Note on #715:** Verified that `aria-hidden={!isOpen}` is already present on the NavBar mobile menu container for screen reader accessibility; no further adjustments were needed.

### UI Improvements
- Filters can now be easily toggled on mobile, significantly improving accessibility for users exploring courses on small screens.
- Stat cards handle long numbers and text gracefully at middle breakpoints.



closes #704 

closes #705 

closes #709 

closes #715 
