### PR TITLE
fix(#767): add no-console ESLint rule to eslint.config.mjs

### DIFF
--- a/frontend-v2/eslint.config.mjs
+++ b/frontend-v2/eslint.config.mjs
@@ -13,6 +13,11 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
   ]),
+  {
+    rules: {
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+    },
+  },
 ]);
 
 export default eslintConfig;


### PR DESCRIPTION
Adds 'no-console': ['warn', { allow: ['warn', 'error'] }] rule so console.log calls (e.g. CourseTable onRowClick, RegisterPage onSubmit) will surface as ESLint warnings and be caught before merging.

## Description  
<!-- Provide a brief summary of the changes in this PR. Explain what was modified and why. -->  

## Related Issues  
<!-- Link any related issues using `Closes #issue_number` or `Fixes #issue_number`. This helps track bugs and feature requests. -->  

## Changes Made  
- [ ] <!-- List key changes made in this PR. Use bullet points for clarity. -->  

## How to Test  
<!-- Explain how a reviewer can test these changes. Provide commands, steps, or expected results if applicable. -->  

## Screenshots (if applicable)  
<!-- If your PR affects the UI, upload screenshots to show the changes visually. -->  

## Checklist  
- [ ] My code follows the project's coding style.  
- [ ] I have tested these changes locally.  
- [ ] Documentation has been updated where necessary.  
closes #767 