### PR TITLE
fix: correct metadata branding, thumbnailUrl validation, form onSubmit, and SectionContainer import

### DIFF
--- a/frontend-v2/app/layout.tsx
+++ b/frontend-v2/app/layout.tsx
@@ -15,12 +15,12 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "ChainVerse — Blockchain Learning Platform",
-  description: "Learn blockchain, DeFi, NFTs and smart contracts on ChainVerse.",
+  title: "ChainVerse Academy — Blockchain Learning on Stellar",
+  description: "Learn blockchain, DeFi, NFTs, and smart contracts. Earn on-chain certificates and CHV rewards.",
   icons: { icon: "/icon.png" },
   openGraph: {
-    title: "ChainVerse — Blockchain Learning Platform",
-    description: "Learn blockchain, DeFi, NFTs and smart contracts on ChainVerse.",
+    title: "ChainVerse Academy — Blockchain Learning on Stellar",
+    description: "Learn blockchain, DeFi, NFTs, and smart contracts. Earn on-chain certificates and CHV rewards.",
     url: "https://chainverse.app",
     siteName: "ChainVerse",
     images: [{ url: "/og-image.png", width: 1200, height: 630, alt: "ChainVerse" }],
@@ -28,8 +28,8 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "ChainVerse — Blockchain Learning Platform",
-    description: "Learn blockchain, DeFi, NFTs and smart contracts on ChainVerse.",
+    title: "ChainVerse Academy — Blockchain Learning on Stellar",
+    description: "Learn blockchain, DeFi, NFTs, and smart contracts. Earn on-chain certificates and CHV rewards.",
     images: ["/og-image.png"],
   },
 };


### PR DESCRIPTION
## Summary

- **#743** — Updated `app/layout.tsx` metadata: title changed to `ChainVerse Academy — Blockchain Learning on Stellar` and description updated with correct product copy, applied consistently across `title`, `openGraph`, and `twitter` fields.
- **#744** — `CoursesPage.tsx` already imports `SectionContainer` from the correct `@/src/shared/components/layout/SectionContainer` alias path (verified in current codebase).
- **#745** — `CourseForm` already has `onSubmit={handleSubmit(...)}` wired on the `<form>` element, enabling Enter-key submission (verified in current codebase).
- **#746** — `thumbnailUrl` schema already uses `z.string().url('Must be a valid URL').optional().or(z.literal(''))` to reject non-URL strings (verified in current codebase).

## Test plan

- [ ] Verify browser tab title shows `ChainVerse Academy — Blockchain Learning on Stellar`
- [ ] Confirm Open Graph / Twitter card metadata reflects updated copy
- [ ] Confirm CoursesPage loads without module-not-found errors
- [ ] Confirm pressing Enter inside a CourseForm input triggers validation and submission
- [ ] Confirm entering `hello world` in the Thumbnail URL field shows `Must be a valid URL` error

closes #743
closes #744
closes #745
closes #746