### PR TITLE
fix: resolve landing page, footer icons, copyright year, and HeroSection animation

### DIFF
--- a/frontend-v2/app/page.tsx
+++ b/frontend-v2/app/page.tsx
@@ -1,13 +1,5 @@
-import { EmptyState } from "@/src/shared/components/ui/EmptyState";
+import { LandingPage } from '@/src/pages/LandingPage/LandingPage';
 
 export default function Page() {
-  return (
-    <div>
-      <EmptyState
-        title="testing empty state"
-        description="to use in an example"
-      />
-      Page
-    </div>
-  );
+  return <LandingPage />;
 }

--- a/frontend-v2/src/shared/components/Footer.tsx
+++ b/frontend-v2/src/shared/components/Footer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { FaWallet, FaGlobe, FaCog } from 'react-icons/fa';
+import { Wallet, Globe, Settings } from 'lucide-react';
 
 const Footer = () => {
   return (
@@ -9,7 +9,7 @@ const Footer = () => {
       <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
         {/* Earn Crypto */}
         <div className="flex flex-col items-center">
-          <FaWallet className="text-blue-500 text-3xl mb-2" />
+          <Wallet className="text-blue-500 w-8 h-8 mb-2" />
           <h3 className="font-semibold text-lg">Earn Crypto</h3>
           <p className="text-sm">
             Get paid directly in XLM for each student enrollment
@@ -18,14 +18,14 @@ const Footer = () => {
 
         {/* Global Reach */}
         <div className="flex flex-col items-center">
-          <FaGlobe className="text-blue-500 text-3xl mb-2" />
+          <Globe className="text-blue-500 w-8 h-8 mb-2" />
           <h3 className="font-semibold text-lg">Global Reach</h3>
           <p className="text-sm">Connect with students from around the world</p>
         </div>
 
         {/* Build Authority */}
         <div className="flex flex-col items-center">
-          <FaCog className="text-blue-500 text-3xl mb-2" />
+          <Settings className="text-blue-500 w-8 h-8 mb-2" />
           <h3 className="font-semibold text-lg">Build Authority</h3>
           <p className="text-sm">
             Establish yourself as a thought leader in blockchain
@@ -34,7 +34,7 @@ const Footer = () => {
       </div>
 
       <div className="border-t border-gray-300 mt-8 pt-4 text-center text-sm">
-        <p>&copy; 2025 ChainVerse Academy. All rights reserved.</p>
+        <p>&copy; {new Date().getFullYear()} ChainVerse Academy. All rights reserved.</p>
         <div className="mt-2 space-x-4">
           <Link href="/terms" className="text-blue-500 hover:underline">
             Terms

--- a/frontend-v2/src/shared/components/HeroSection.tsx
+++ b/frontend-v2/src/shared/components/HeroSection.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 
 import { Button } from './ui/button';
 import { ArrowRight } from 'lucide-react';
-import { BlockchainAnimation } from './animations/blockchain-animation';
 
 const HeroSection: React.FC = () => {
   return (
@@ -41,7 +40,10 @@ const HeroSection: React.FC = () => {
         </div>
       </div>
       <div className="flex items-center justify-center">
-        <BlockchainAnimation />
+        {/* Temporary static visual — BlockchainAnimation will be ported from v1 */}
+        <div className="w-full h-64 bg-gradient-to-br from-blue-600 to-indigo-600 rounded-2xl flex items-center justify-center">
+          <span className="text-white text-4xl">⛓️</span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

This PR fixes four bugs reported in the v2 frontend:

### #742 — app/page.tsx renders EmptyState debug stub instead of landing page
- Replaced `<EmptyState title="testing empty state" />` with `<LandingPage />` from `@/src/pages/LandingPage/LandingPage`

### #741 — Footer imports react-icons which is not in package.json
- Replaced `FaWallet`, `FaGlobe`, `FaCog` from `react-icons/fa` with `Wallet`, `Globe`, `Settings` from `lucide-react` (already installed)

### #740 — Footer copyright year hardcoded as 2025
- Updated copyright to use `{new Date().getFullYear()}` so it stays current automatically

### #739 — HeroSection imports BlockchainAnimation which doesn't exist in v2
- Removed broken import of `./animations/blockchain-animation` (file only exists in frontend-v1)
- Replaced with a temporary gradient placeholder until the animation is ported to v2

## Files Changed
- `frontend-v2/app/page.tsx`
- `frontend-v2/src/shared/components/Footer.tsx`
- `frontend-v2/src/shared/components/HeroSection.tsx`

Closes #739
Closes #740
Closes #741
Closes #742