### PR TITLE
refactor: complete lib/index.ts barrel, confirm api-client dedup and contact route

### DIFF
--- a/frontend-v2/lib/index.ts
+++ b/frontend-v2/lib/index.ts
@@ -1,1 +1,2 @@
-export { cn } from './utils';
+export { cn, formatDate } from './utils';
+export { queryClient, registerGlobalErrorHandler } from './query-client';

--- a/frontend-v2/lib/utils.ts
+++ b/frontend-v2/lib/utils.ts
@@ -4,3 +4,14 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Formats a date string or Date object into a human-readable format.
+ */
+export function formatDate(date: string | Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(date));
+}


### PR DESCRIPTION
## Summary

Addresses four related refactor issues that prevent module-not-found crashes, eliminate duplicated HTTP stacks, and ensure the contact route is reachable by Next.js App Router.

---

### #754 — Create `lib/index.ts` barrel with full re-exports

**Problem:** `app/layout.tsx` and other components import from `@/lib` (resolving to `lib/index.ts`), but the file only re-exported `cn`. The `queryClient`, `registerGlobalErrorHandler`, and `formatDate` symbols were missing, causing module-not-found crashes at runtime.

**Fix:**
- Added `formatDate()` to `frontend-v2/lib/utils.ts` (mirrors the implementation already in `src/lib/utils.ts`)
- Updated `frontend-v2/lib/index.ts` to re-export all four symbols:
  ```ts
  export { cn, formatDate } from './utils';
  export { queryClient, registerGlobalErrorHandler } from './query-client';
  ```

Closes #754

---

### #752 — `instructor.service.ts` already uses `apiClient`

**Status: Already resolved in codebase.**  
`src/features/instructors/services/instructor.service.ts` no longer contains a custom `request()` helper — it imports and uses `apiClient` from `@/src/lib/api-client` for all operations.

Closes #752

---

### #753 — `student.service.ts` already uses `apiClient`

**Status: Already resolved in codebase.**  
`src/features/students/services/student.service.ts` no longer contains a custom `request()` helper — it imports and uses `apiClient` from `@/src/lib/api-client` for all operations.

Closes #753

---

### #751 — Contact page already in `app/(main)/contact/`

**Status: Already resolved in codebase.**  
The contact route files are at `frontend-v2/app/(main)/contact/page.tsx` and `frontend-v2/app/(main)/contact/layout.tsx`, correctly placed within the Next.js App Router `app/` directory and fully reachable.

Closes #751

---

## Files Changed

| File | Change |
|------|--------|
| `frontend-v2/lib/utils.ts` | Added `formatDate()` export |
| `frontend-v2/lib/index.ts` | Added `formatDate`, `queryClient`, `registerGlobalErrorHandler` re-exports |

## Testing

- Verified no custom `request()` helpers remain in `instructor.service.ts` or `student.service.ts`
- Verified contact page exists at `app/(main)/contact/`
- Verified `lib/index.ts` now exports all four expected symbols