### PR TITLE
fix: #783 / shortcut for search, #784 CourseCard image placeholder, #785 loading.tsx, #786 Vitest migration

### DIFF
--- a/frontend-v2/src/features/courses/components/courseCard.tsx
+++ b/frontend-v2/src/features/courses/components/courseCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Star, Heart, ShoppingCart } from 'lucide-react';
+import { Star, Heart, ShoppingCart, BookOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import Image from 'next/image';
@@ -69,8 +69,10 @@ export function CourseCard({
             className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
           />
         ) : (
-          <div className="w-full h-full flex items-center justify-center">
-            <span className="text-white text-sm font-semibold">{category}</span>
+          /* #784 — proper placeholder when no image is provided */
+          <div className="w-full h-full flex flex-col items-center justify-center gap-2">
+            <BookOpen className="text-white/70" size={32} aria-hidden="true" />
+            <span className="text-white/90 text-xs font-semibold uppercase tracking-wide">{category}</span>
           </div>
         )}
         {/* Wishlist Button */}

--- a/frontend-v2/src/features/courses/pages/CoursesPage.tsx
+++ b/frontend-v2/src/features/courses/pages/CoursesPage.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import React, { Suspense, useState, useEffect, useMemo } from 'react';
-import { Search } from 'lucide-react';
-import React, { Suspense, useState, useEffect } from 'react';
+import React, { Suspense, useState, useEffect, useMemo, useRef } from 'react';
 import { Search, SlidersHorizontal } from 'lucide-react';
 import { CourseFilters } from '../components/CourseFilters';
 import { CourseList } from '../components/CourseList';
@@ -32,8 +30,21 @@ function CourseGrid() {
   const [priceRange, setPriceRange] = useState(500);
   const [currentPage, setCurrentPage] = useState(1);
   const [showFilters, setShowFilters] = useState(false);
+  const searchRef = useRef<HTMLInputElement>(null);
 
   const { courses, isLoading, error } = useCourses();
+
+  // #783 — press "/" to focus the search input (like GitHub / Notion / Linear)
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === '/' && document.activeElement?.tagName !== 'INPUT' && document.activeElement?.tagName !== 'TEXTAREA') {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   // #269 — reset to page 1 whenever any filter changes
   useEffect(() => {
@@ -82,12 +93,17 @@ function CourseGrid() {
             size={20}
           />
           <input
+            ref={searchRef}
             type="text"
             placeholder="Search courses..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            className="w-full pl-10 pr-12 py-3 border border-gray-300 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
           />
+          {/* #783 — "/" shortcut hint badge */}
+          <kbd className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden sm:inline-flex items-center gap-1 rounded border border-gray-300 bg-gray-100 px-1.5 py-0.5 text-xs font-mono text-gray-500 select-none">
+            /
+          </kbd>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Addresses four issues across UX polish and test correctness.

### #783 — Keyboard shortcut (/) to focus courses search input
- Added `useRef<HTMLInputElement>` (`searchRef`) to `CourseGrid`
- Registered a `window.addEventListener('keydown', handler)` that calls `searchRef.current?.focus()` when `e.key === '/'` and the active element is not an `INPUT` or `TEXTAREA` (prevents hijacking while user is already typing)
- Attached `ref={searchRef}` to the search `<input>`; widened right padding to `pr-12` to make room for the badge
- Added a `<kbd>/</kbd>` badge absolutely positioned at the right edge of the input (hidden on mobile, visible on `sm:` and up), matching the convention on GitHub, Notion, and Linear

### #784 — Proper placeholder in CourseCard when image is empty
- Imported `BookOpen` from `lucide-react`
- Replaced the bare `<span>{category}</span>` fallback with a centred flex column containing a `<BookOpen>` icon (`text-white/70`, `size={32}`) plus the `{category}` label — gives the card a meaningful visual state instead of looking broken

### #785 — app/loading.tsx already present
`frontend-v2/app/loading.tsx` already exists and renders a centred `<Spinner size="lg" />`. No code change was needed.

### #786 — test/api/api.test.ts already migrated to Vitest
`frontend-v2/test/api/api.test.ts` already imports `vi` from `vitest` and uses `vi.fn()` / `vi.mocked()` throughout. No code change was needed.

## Files changed
- `frontend-v2/src/features/courses/pages/CoursesPage.tsx` — #783
- `frontend-v2/src/features/courses/components/courseCard.tsx` — #784

Closes #783
Closes #784
Closes #785
Closes #786