### PR TITLE
fix: resolve responsive UI issues (#714, #716, #717, #721)

### DIFF
--- a/frontend-v2/src/features/auth/components/AuthForm.tsx
+++ b/frontend-v2/src/features/auth/components/AuthForm.tsx
@@ -13,7 +13,7 @@ export const AuthForm: React.FC<AuthFormProps> = ({ title, subtitle, children, o
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50 flex items-center justify-center px-4 py-12">
       <div className="w-full max-w-md">
-        <div className="bg-white rounded-2xl shadow-xl border border-gray-100 overflow-hidden">
+        <div className="w-full max-w-md mx-auto bg-white rounded-2xl shadow-xl border border-gray-100 overflow-hidden p-6 sm:p-8">
           {/* Header */}
           <div className="bg-gradient-to-r from-blue-600 to-indigo-600 px-8 py-12">
             <h1 className="text-3xl font-bold text-white mb-2">{title}</h1>

--- a/frontend-v2/src/features/courses/components/courseCard.tsx
+++ b/frontend-v2/src/features/courses/components/courseCard.tsx
@@ -137,7 +137,7 @@ export function CourseCard({
           <Button
             onClick={onAddToCart}
             size="sm"
-            className="bg-[var(--dt-primary)] hover:bg-[var(--dt-primary-hover)] text-white font-semibold gap-2 group/btn"
+            className="min-h-[44px] min-w-[44px] bg-[var(--dt-primary)] hover:bg-[var(--dt-primary-hover)] text-white font-semibold gap-2 group/btn"
           >
             <ShoppingCart size={16} className="group-hover/btn:scale-110 transition-transform" />
             <span className="hidden sm:inline">Add</span>

--- a/frontend-v2/src/shared/components/FeaturedCourses.tsx
+++ b/frontend-v2/src/shared/components/FeaturedCourses.tsx
@@ -51,7 +51,7 @@ const FeaturedCourses: React.FC = () => {
   ];
 
   return (
-    <section className="lg:md:py-12 py-8 bg-gray-50">
+    <section className="py-8 md:py-12 bg-gray-50">
       <div className="text-center mb-10">
         <h2 className="text-3xl font-bold mb-2">Featured Courses</h2>
         <p className="text-gray-600">Start your blockchain journey today</p>

--- a/frontend-v2/src/shared/components/layout/NavBar.tsx
+++ b/frontend-v2/src/shared/components/layout/NavBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib';
@@ -10,6 +10,8 @@ import { colors } from '@/src/shared/constants/design-tokens';
 export const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
+
+  useEffect(() => { setIsOpen(false); }, [pathname]);
 
   const toggleMenu = () => setIsOpen(!isOpen);
 


### PR DESCRIPTION
## Summary

This PR fixes 4 responsive UI issues assigned to Husten150.

### Changes

**#714 — NavBar mobile menu close-on-navigation**
- Added useEffect to auto-close the mobile menu when pathname changes
- All mobile links already had onClick={() => setIsOpen(false)}

**#716 — CourseCard Add-to-cart button tap target at sm breakpoint**
- Added min-h-[44px] min-w-[44px] to the Add-to-cart button to meet 44×44px minimum tap target

**#717 — FeaturedCourses section invalid Tailwind class**
- Replaced invalid lg:md:py-12 with valid py-8 md:py-12

**#721 — AuthForm has no max-width on mobile**
- Added w-full max-w-md mx-auto and responsive padding p-6 sm:p-8 to the card wrapper

Closes #714, Closes #716, Closes #717, Closes #721