### PR TITLE
fix: resolve bugs #735 #736 #737 #738 — LoginPage links, StudentDashboard name, FeaturedCourses Tailwind

### DIFF
--- a/frontend-v1/components/FeaturedCourses.tsx
+++ b/frontend-v1/components/FeaturedCourses.tsx
@@ -51,7 +51,7 @@ const FeaturedCourses: React.FC = () => {
   ];
 
   return (
-    <section className="lg:md:py-12 py-8 bg-gray-50">
+    <section className="py-8 md:py-12 bg-gray-50">
       <div className="text-center mb-10">
         <h2 className="text-3xl font-bold mb-2">Featured Courses</h2>
         <p className="text-gray-600">Start your blockchain journey today</p>

--- a/frontend-v2/src/features/auth/pages/LoginPage.tsx
+++ b/frontend-v2/src/features/auth/pages/LoginPage.tsx
@@ -119,7 +119,7 @@ export const LoginPage: React.FC = () => {
 
       {/* Forgot Password */}
       <div className="text-right">
-        <Link href="/auth/reset-password" className="text-blue-600 hover:text-blue-700 text-sm font-medium">
+        <Link href="/reset-password" className="text-blue-600 hover:text-blue-700 text-sm font-medium">
           Forgot password?
         </Link>
       </div>
@@ -143,7 +143,7 @@ export const LoginPage: React.FC = () => {
       {/* Sign Up Link */}
       <p className="text-center text-gray-600 text-sm">
         Don&apos;t have an account?{' '}
-        <Link href="/auth/register" className="text-blue-600 hover:text-blue-700 font-semibold">
+        <Link href="/register" className="text-blue-600 hover:text-blue-700 font-semibold">
           Sign up
         </Link>
       </p>

--- a/frontend-v2/src/features/students/pages/StudentDashboardPage.tsx
+++ b/frontend-v2/src/features/students/pages/StudentDashboardPage.tsx
@@ -4,7 +4,7 @@ import React, { Suspense, useEffect, useState } from 'react';
 import { BookOpen, Clock, Trophy, TrendingUp } from 'lucide-react';
 import { UserActivityChart } from '../components/UserActivityChart';
 import { studentService } from '../services/student.service';
-import { useSession } from '@/src/features/auth/hooks/useSession';
+import { useAuthStore } from '@/src/store/authStore';
 import type { Student, EnrollmentRecord } from '../types/students.types';
 
 interface DashboardStats {
@@ -23,14 +23,14 @@ const STAT_COLORS = [
 ];
 
 export const StudentDashboardPage: React.FC = () => {
-  const { token } = useSession();
+  const authUser = useAuthStore((state) => state.user);
   const [student, setStudent] = useState<Student | null>(null);
   const [enrollments, setEnrollments] = useState<EnrollmentRecord[]>([]);
   const [stats, setStats] = useState<DashboardStats | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    if (!token) return;
+    if (!authUser) return;
     setIsLoading(true);
     Promise.all([
       studentService.list(1, 1),
@@ -49,7 +49,7 @@ export const StudentDashboardPage: React.FC = () => {
       })
       .catch(() => {})
       .finally(() => setIsLoading(false));
-  }, [token]);
+  }, [authUser]);
 
   const statItems = stats
     ? [
@@ -60,7 +60,7 @@ export const StudentDashboardPage: React.FC = () => {
       ]
     : [];
 
-  const firstName = student?.firstName ?? 'there';
+  const firstName = authUser?.firstName ?? 'there';
 
   return (
     <div className="min-h-screen bg-gray-50">


### PR DESCRIPTION
## Summary

- **#738** `FeaturedCourses`: removed invalid chained Tailwind prefix `lg:md:py-12` (silently ignored) — replaced with the correct `py-8 md:py-12`
- **#736 / #737** `StudentDashboardPage`: replaced broken `useSession` token destructure (hook never returned a token, so the stats `useEffect` never ran) with `useAuthStore`; `firstName` is now read from the persisted auth store instead of a stale API response
- **#735** `LoginPage`: corrected `<Link>` paths from non-existent `/auth/reset-password` and `/auth/register` to `/reset-password` and `/register`

## Test plan

- [ ] Landing page renders FeaturedCourses with correct vertical padding on all breakpoints
- [ ] Logged-in student dashboard greets the real user's first name (not a hardcoded value)
- [ ] Dashboard stats load correctly (effect now triggers on `authUser` instead of always-undefined `token`)
- [ ] "Forgot password?" and "Sign up" links on the login page navigate without a full page reload and reach the correct routes

closes #738
closes #736
closes #737
closes #735