### PR TITLE
fix(a11y/ux): associate course filter/form labels and add empty filter state

### DIFF
--- a/frontend-v2/src/features/courses/components/CourseFilters.tsx
+++ b/frontend-v2/src/features/courses/components/CourseFilters.tsx
@@ -38,8 +38,13 @@ export const CourseFilters: React.FC<CourseFiltersProps> = ({
           <h3 className="text-sm font-semibold text-gray-900 mb-3">Category</h3>
           <div className="space-y-2">
             {CATEGORIES.map((category) => (
-              <label key={category} className="flex items-center gap-2 cursor-pointer">
+              <label
+                key={category}
+                htmlFor={`category-${category}`}
+                className="flex items-center gap-2 cursor-pointer"
+              >
                 <input
+                  id={`category-${category}`}
                   type="checkbox"
                   checked={selectedCategories.includes(category)}
                   onChange={() => handleCategoryToggle(category)}
@@ -56,8 +61,13 @@ export const CourseFilters: React.FC<CourseFiltersProps> = ({
           <h3 className="text-sm font-semibold text-gray-900 mb-3">Level</h3>
           <div className="space-y-2">
             {LEVELS.map((level) => (
-              <label key={level} className="flex items-center gap-2 cursor-pointer">
+              <label
+                key={level}
+                htmlFor={`level-${level}`}
+                className="flex items-center gap-2 cursor-pointer"
+              >
                 <input
+                  id={`level-${level}`}
                   type="radio"
                   name="level"
                   checked={selectedLevel === level}

--- a/frontend-v2/src/features/courses/components/CourseList.tsx
+++ b/frontend-v2/src/features/courses/components/CourseList.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Star } from 'lucide-react';
-import { EmptyState } from '@/src/shared/components/ui/EmptyState';
+import { BookOpen, Star } from 'lucide-react';
 import Link from 'next/link';
 
 interface CourseItem {
@@ -19,15 +18,25 @@ interface CourseItem {
 
 interface CourseListProps {
   courses: CourseItem[];
+  onClearFilters?: () => void;
 }
 
-export const CourseList: React.FC<CourseListProps> = ({ courses }) => {
+export const CourseList: React.FC<CourseListProps> = ({ courses, onClearFilters }) => {
   if (courses.length === 0) {
     return (
-      <EmptyState
-        title="No courses found"
-        description="Try adjusting your filters."
-      />
+      <div className="col-span-full flex flex-col items-center justify-center py-16 gap-4">
+        <BookOpen size={48} className="text-gray-300" />
+        <p className="text-gray-500 text-lg font-medium">No courses match your filters</p>
+        {onClearFilters && (
+          <button
+            type="button"
+            onClick={onClearFilters}
+            className="text-indigo-600 hover:underline text-sm"
+          >
+            Clear all filters
+          </button>
+        )}
+      </div>
     );
   }
 

--- a/frontend-v2/src/features/courses/pages/CoursesPage.tsx
+++ b/frontend-v2/src/features/courses/pages/CoursesPage.tsx
@@ -84,6 +84,14 @@ function CourseGrid() {
     [filtered, currentPage]
   );
 
+  const handleClearFilters = () => {
+    setSearchQuery('');
+    setSelectedCategories([]);
+    setSelectedLevel('All');
+    setPriceRange(500);
+    setCurrentPage(1);
+  };
+
   return (
     <>
       <div className="mb-8">
@@ -141,7 +149,7 @@ function CourseGrid() {
               ))}
             </div>
           ) : (
-            <CourseList courses={paginated} />
+            <CourseList courses={paginated} onClearFilters={handleClearFilters} />
           )}
 
           {!isLoading && totalPages > 1 && (

--- a/frontend-v2/src/features/instructors/components/CourseForm.tsx
+++ b/frontend-v2/src/features/instructors/components/CourseForm.tsx
@@ -58,8 +58,9 @@ export const CourseForm: React.FC<CourseFormProps> = ({
     <form className="space-y-6" onSubmit={handleSubmit((data) => onSubmit(data, isEditing ? 'update' : 'publish'))}>
       {/* Title */}
       <div>
-        <label className="block text-sm font-semibold text-gray-700 mb-2">Title</label>
+        <label htmlFor="course-title" className="block text-sm font-semibold text-gray-700 mb-2">Title</label>
         <input
+          id="course-title"
           type="text"
           placeholder="Course title"
           className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 transition ${
@@ -72,8 +73,9 @@ export const CourseForm: React.FC<CourseFormProps> = ({
 
       {/* Description */}
       <div>
-        <label className="block text-sm font-semibold text-gray-700 mb-2">Description</label>
+        <label htmlFor="course-description" className="block text-sm font-semibold text-gray-700 mb-2">Description</label>
         <textarea
+          id="course-description"
           rows={4}
           placeholder="Course description"
           className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 transition resize-none ${
@@ -87,8 +89,9 @@ export const CourseForm: React.FC<CourseFormProps> = ({
       {/* Category & Level */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
-          <label className="block text-sm font-semibold text-gray-700 mb-2">Category</label>
+          <label htmlFor="course-category" className="block text-sm font-semibold text-gray-700 mb-2">Category</label>
           <select
+            id="course-category"
             className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 transition ${
               errors.category ? 'border-red-300 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
             }`}
@@ -103,8 +106,9 @@ export const CourseForm: React.FC<CourseFormProps> = ({
         </div>
 
         <div>
-          <label className="block text-sm font-semibold text-gray-700 mb-2">Level</label>
+          <label htmlFor="course-level" className="block text-sm font-semibold text-gray-700 mb-2">Level</label>
           <select
+            id="course-level"
             className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 transition ${
               errors.level ? 'border-red-300 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
             }`}
@@ -121,8 +125,9 @@ export const CourseForm: React.FC<CourseFormProps> = ({
 
       {/* Price */}
       <div>
-        <label className="block text-sm font-semibold text-gray-700 mb-2">Price ($)</label>
+        <label htmlFor="course-price" className="block text-sm font-semibold text-gray-700 mb-2">Price ($)</label>
         <input
+          id="course-price"
           type="number"
           step="0.01"
           min="0"
@@ -137,8 +142,9 @@ export const CourseForm: React.FC<CourseFormProps> = ({
 
       {/* Thumbnail URL */}
       <div>
-        <label className="block text-sm font-semibold text-gray-700 mb-2">Thumbnail URL</label>
+        <label htmlFor="course-thumbnail" className="block text-sm font-semibold text-gray-700 mb-2">Thumbnail URL</label>
         <input
+          id="course-thumbnail"
           type="text"
           placeholder="https://example.com/image.jpg"
           className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"


### PR DESCRIPTION
closes #777 
closes #778 
closes #780 
closes #782

## Summary
- Associate CourseFilters checkboxes/radios with explicit `id` + `htmlFor` pairs for better AT compatibility
- Associate all CourseForm fields with matching `htmlFor` / `id` attributes
- Show a clear empty state in CourseList when filters return no results, with a "Clear all filters" action
- Pagination page buttons already expose descriptive `aria-label` and `aria-current` (verified, no change needed)

## Changes

### Task 1 — CourseFilters label association
Category checkboxes and level radios now use explicit IDs (`category-${category}`, `level-${level}`) paired with `htmlFor` on wrapping labels.

### Task 2 — CoursesPage pagination a11y
Already implemented: page number buttons use `aria-label={`Go to page ${page}`}` and `aria-current="page"` for the active page.

### Task 3 — CourseForm label association
All fields (title, description, category, level, price, thumbnail) now have matching `htmlFor` / `id` pairs (`course-title`, `course-description`, etc.).

### Task 4 — CourseList empty state
When `courses.length === 0`, render a centered empty state with BookOpen icon, "No courses match your filters", and a "Clear all filters" button wired via `onClearFilters` from CoursesPage (resets search, categories, level, price, and page).

## Test plan
- [ ] Open Courses page → toggle category/level filters; labels/inputs remain clickable and associated in the accessibility tree
- [ ] With filters that yield zero results → empty state appears with message + Clear all filters
- [ ] Click Clear all filters → filters/search reset and courses reappear
- [ ] Pagination (when >1 page) → screen reader announces "Go to page N"; current page has `aria-current="page"`
- [ ] Open instructor CourseForm → each label focuses its matching input/select/textarea