### PR TITLE
fix(a11y): screen reader labels, progressbar ARIA, and shared focus-ring

### DIFF
--- a/frontend-v2/app/(main)/contact/page.tsx
+++ b/frontend-v2/app/(main)/contact/page.tsx
@@ -238,7 +238,7 @@ const ContactUsPage = () => {
                       onChange={(e) =>
                         handleInputChange("fullName", e.target.value)
                       }
-                      className={`block w-full pl-10 pr-3 py-3 border rounded-lg placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-transparent transition-all ${
+                      className={`block w-full pl-10 pr-3 py-3 border rounded-lg placeholder-gray-400 focus-ring focus:border-transparent transition-all ${
                         errors.fullName ? "border-red-500" : "border-gray-300"
                       }`}
                       placeholder="Enter your full name"
@@ -272,7 +272,7 @@ const ContactUsPage = () => {
                         onChange={(e) =>
                           handleInputChange("email", e.target.value)
                         }
-                        className={`block w-full pl-10 pr-3 py-3 border rounded-lg placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-transparent transition-all ${
+                        className={`block w-full pl-10 pr-3 py-3 border rounded-lg placeholder-gray-400 focus-ring focus:border-transparent transition-all ${
                           errors.email ? "border-red-500" : "border-gray-300"
                         }`}
                         placeholder="your.email@example.com"
@@ -305,7 +305,7 @@ const ContactUsPage = () => {
                         onChange={(e) =>
                           handleInputChange("phone", e.target.value)
                         }
-                        className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-transparent transition-all"
+                        className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg placeholder-gray-400 focus-ring focus:border-transparent transition-all"
                         placeholder="+234 800 000 0000"
                       />
                     </div>
@@ -332,7 +332,7 @@ const ContactUsPage = () => {
                       onChange={(e) =>
                         handleInputChange("company", e.target.value)
                       }
-                      className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-transparent transition-all"
+                      className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg placeholder-gray-400 focus-ring focus:border-transparent transition-all"
                       placeholder="Your company name"
                     />
                   </div>
@@ -357,7 +357,7 @@ const ContactUsPage = () => {
                       onChange={(e) =>
                         handleInputChange("subject", e.target.value)
                       }
-                      className={`block w-full pl-10 pr-3 py-3 border rounded-lg placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-transparent transition-all ${
+                      className={`block w-full pl-10 pr-3 py-3 border rounded-lg placeholder-gray-400 focus-ring focus:border-transparent transition-all ${
                         errors.subject ? "border-red-500" : "border-gray-300"
                       }`}
                       placeholder="How can we help you?"
@@ -386,7 +386,7 @@ const ContactUsPage = () => {
                     onChange={(e) =>
                       handleInputChange("message", e.target.value)
                     }
-                    className={`block w-full px-3 py-3 border rounded-lg placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-transparent transition-all resize-none ${
+                    className={`block w-full px-3 py-3 border rounded-lg placeholder-gray-400 focus-ring focus:border-transparent transition-all resize-none ${
                       errors.message ? "border-red-500" : "border-gray-300"
                     }`}
                     placeholder="Tell us more about your inquiry..."
@@ -406,7 +406,7 @@ const ContactUsPage = () => {
                 <button
                   onClick={handleSubmit}
                   disabled={isLoading}
-                  className="w-full bg-gray-900 text-white py-3 px-4 rounded-lg font-medium hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
+                  className="w-full bg-gray-900 text-white py-3 px-4 rounded-lg font-medium hover:bg-gray-800 focus-ring transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
                 >
                   {isLoading ? (
                     <>

--- a/frontend-v2/app/(main)/notifications/page.tsx
+++ b/frontend-v2/app/(main)/notifications/page.tsx
@@ -127,7 +127,7 @@ export default function NotificationsPage() {
                   {!n.isRead && (
                     <button
                       onClick={() => markRead(n.id)}
-                      className="text-xs text-indigo-600 hover:text-indigo-700 font-medium whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+                      className="text-xs text-indigo-600 hover:text-indigo-700 font-medium whitespace-nowrap focus-ring rounded"
                     >
                       Mark read
                     </button>

--- a/frontend-v2/app/(main)/profile/page.tsx
+++ b/frontend-v2/app/(main)/profile/page.tsx
@@ -124,7 +124,7 @@ export default function ProfilePage() {
                   value={profile.firstName}
                   onChange={(e) => setProfile((p) => ({ ...p, firstName: e.target.value }))}
                   placeholder="Jane"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus-ring text-sm"
                 />
               </div>
               <div>
@@ -137,7 +137,7 @@ export default function ProfilePage() {
                   value={profile.lastName}
                   onChange={(e) => setProfile((p) => ({ ...p, lastName: e.target.value }))}
                   placeholder="Doe"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus-ring text-sm"
                 />
               </div>
             </div>
@@ -152,7 +152,7 @@ export default function ProfilePage() {
                 value={profile.avatarUrl}
                 onChange={(e) => setProfile((p) => ({ ...p, avatarUrl: e.target.value }))}
                 placeholder="https://example.com/avatar.png"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus-ring text-sm"
               />
             </div>
 
@@ -166,7 +166,7 @@ export default function ProfilePage() {
                 value={profile.bio}
                 onChange={(e) => setProfile((p) => ({ ...p, bio: e.target.value }))}
                 placeholder="Tell us a bit about yourself..."
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm resize-none"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus-ring text-sm resize-none"
               />
             </div>
 
@@ -174,7 +174,7 @@ export default function ProfilePage() {
               <button
                 type="submit"
                 disabled={saveStatus === 'saving'}
-                className="px-5 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition text-sm font-medium disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                className="px-5 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition text-sm font-medium disabled:opacity-50 focus-ring"
               >
                 {saveStatus === 'saving' ? 'Saving...' : 'Save Profile'}
               </button>
@@ -198,7 +198,7 @@ export default function ProfilePage() {
                 value={passwords.currentPassword}
                 onChange={(e) => setPasswords((p) => ({ ...p, currentPassword: e.target.value }))}
                 autoComplete="current-password"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus-ring text-sm"
               />
             </div>
             <div>
@@ -211,7 +211,7 @@ export default function ProfilePage() {
                 value={passwords.newPassword}
                 onChange={(e) => setPasswords((p) => ({ ...p, newPassword: e.target.value }))}
                 autoComplete="new-password"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus-ring text-sm"
               />
             </div>
             <div>
@@ -224,7 +224,7 @@ export default function ProfilePage() {
                 value={passwords.confirmPassword}
                 onChange={(e) => setPasswords((p) => ({ ...p, confirmPassword: e.target.value }))}
                 autoComplete="new-password"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus-ring text-sm"
               />
             </div>
 
@@ -234,7 +234,7 @@ export default function ProfilePage() {
               <button
                 type="submit"
                 disabled={passwordStatus === 'saving'}
-                className="px-5 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition text-sm font-medium disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                className="px-5 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition text-sm font-medium disabled:opacity-50 focus-ring"
               >
                 {passwordStatus === 'saving' ? 'Updating...' : 'Update Password'}
               </button>

--- a/frontend-v2/app/globals.css
+++ b/frontend-v2/app/globals.css
@@ -116,6 +116,11 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+/* Shared a11y focus ring — use class `focus-ring` on buttons, links, inputs */
+@utility focus-ring {
+  @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/frontend-v2/app/not-found.tsx
+++ b/frontend-v2/app/not-found.tsx
@@ -20,13 +20,13 @@ export default function NotFound() {
       <div className="flex flex-wrap gap-3 justify-center">
         <Link
           href="/"
-          className="px-6 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+          className="px-6 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition font-medium focus-ring"
         >
           Go Home
         </Link>
         <Link
           href="/courses"
-          className="px-6 py-3 border border-gray-300 text-gray-700 bg-white rounded-lg hover:bg-gray-50 transition font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+          className="px-6 py-3 border border-gray-300 text-gray-700 bg-white rounded-lg hover:bg-gray-50 transition font-medium focus-ring"
         >
           Browse Courses
         </Link>

--- a/frontend-v2/src/components/ThemeToggle.tsx
+++ b/frontend-v2/src/components/ThemeToggle.tsx
@@ -42,7 +42,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={toggleTheme}
-      className="p-2 rounded-lg text-gray-500 hover:text-gray-900 bg-gray-50 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-800 dark:hover:bg-gray-700 dark:hover:text-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-300 dark:focus:ring-gray-600"
+      className="p-2 rounded-lg text-gray-500 hover:text-gray-900 bg-gray-50 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-800 dark:hover:bg-gray-700 dark:hover:text-gray-100 transition-colors focus-ring"
       aria-label="Toggle Dark Mode"
     >
       {isDark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}

--- a/frontend-v2/src/components/auth/TwoFactorModal.tsx
+++ b/frontend-v2/src/components/auth/TwoFactorModal.tsx
@@ -52,7 +52,7 @@ export function BiometricLoginView({
 
       <button
         onClick={onSwitchToEmail}
-        className="text-sm text-gray-900 hover:text-gray-700 focus:outline-none focus:underline"
+        className="text-sm text-gray-900 hover:text-gray-700 focus-ring"
       >
         Having trouble? Use email login
       </button>

--- a/frontend-v2/src/components/common/Footer.tsx
+++ b/frontend-v2/src/components/common/Footer.tsx
@@ -162,7 +162,7 @@ export const Footer: React.FC = () => {
                 <input
                   type="email"
                   placeholder="Enter your email"
-                  className="flex-1 md:flex-none px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  className="flex-1 md:flex-none px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus-ring"
                 />
                 <button className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-lg transition">
                   Subscribe

--- a/frontend-v2/src/components/common/StandardFormTemplate.tsx
+++ b/frontend-v2/src/components/common/StandardFormTemplate.tsx
@@ -57,7 +57,7 @@ export function StandardFormTemplate() {
               <input
                 id="fullName"
                 type="text"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-900 transition-colors"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus-ring transition-colors"
                 placeholder="Jane Doe"
               />
             </div>
@@ -72,7 +72,7 @@ export function StandardFormTemplate() {
                 <input
                   id="email"
                   type="email"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-900 transition-colors"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus-ring transition-colors"
                   placeholder="jane@example.com"
                 />
               </div>
@@ -84,7 +84,7 @@ export function StandardFormTemplate() {
                 </label>
                 <select
                   id="role"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-900 transition-colors"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus-ring transition-colors"
                 >
                   <option>Administrator</option>
                   <option>Editor</option>

--- a/frontend-v2/src/components/dashboard/instructor/Header.tsx
+++ b/frontend-v2/src/components/dashboard/instructor/Header.tsx
@@ -65,7 +65,7 @@ export const Header: React.FC<HeaderProps> = ({ onMenuToggle }) => {
                     <input
                         type="text"
                         placeholder="Search everything..."
-                        className="pl-12 pr-4 py-2.5 w-64 xl:w-72 rounded-xl border border-gray-100 bg-gray-50/50 text-sm focus:outline-none focus:ring-4 focus:ring-indigo-500/10 focus:border-indigo-500 focus:bg-white transition-all duration-300"
+                        className="pl-12 pr-4 py-2.5 w-64 xl:w-72 rounded-xl border border-gray-100 bg-gray-50/50 text-sm focus-ring focus:border-indigo-500 focus:bg-white transition-all duration-300"
                     />
                 </div>
 
@@ -100,7 +100,7 @@ export const Header: React.FC<HeaderProps> = ({ onMenuToggle }) => {
                         <button
                             id="profile-menu-button"
                             onClick={toggleProfile}
-                            className="flex items-center gap-3 cursor-pointer group focus:outline-none"
+                            className="flex items-center gap-3 cursor-pointer group focus-ring"
                             aria-haspopup="true"
                             aria-expanded={isProfileOpen}
                             aria-label="Open profile menu"

--- a/frontend-v2/src/features/auth/pages/LoginPage.tsx
+++ b/frontend-v2/src/features/auth/pages/LoginPage.tsx
@@ -77,8 +77,8 @@ export const LoginPage: React.FC = () => {
           type="email"
           placeholder="you@example.com"
           autoComplete="email"
-          className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition ${
-            errors.email ? 'border-red-300 focus-visible:ring-red-500' : 'border-gray-300 focus-visible:ring-blue-500'
+          className={`w-full px-4 py-3 border rounded-lg focus-ring transition ${
+            errors.email ? 'border-red-300 focus-visible:ring-red-500' : 'border-gray-300'
           }`}
           {...register('email')}
         />
@@ -98,8 +98,8 @@ export const LoginPage: React.FC = () => {
             type={showPassword ? 'text' : 'password'}
             placeholder="••••••••"
             autoComplete="current-password"
-            className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition pr-12 ${
-              errors.password ? 'border-red-300 focus-visible:ring-red-500' : 'border-gray-300 focus-visible:ring-blue-500'
+            className={`w-full px-4 py-3 border rounded-lg focus-ring transition pr-12 ${
+              errors.password ? 'border-red-300 focus-visible:ring-red-500' : 'border-gray-300'
             }`}
             {...register('password')}
           />
@@ -107,7 +107,7 @@ export const LoginPage: React.FC = () => {
             type="button"
             aria-label={showPassword ? 'Hide password' : 'Show password'}
             onClick={() => setShowPassword(!showPassword)}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 rounded"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition focus-ring rounded"
           >
             {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
           </button>
@@ -119,7 +119,7 @@ export const LoginPage: React.FC = () => {
 
       {/* Forgot Password */}
       <div className="text-right">
-        <Link href="/auth/reset-password" className="text-blue-600 hover:text-blue-700 text-sm font-medium">
+        <Link href="/auth/reset-password" className="text-blue-600 hover:text-blue-700 text-sm font-medium focus-ring rounded">
           Forgot password?
         </Link>
       </div>
@@ -128,7 +128,7 @@ export const LoginPage: React.FC = () => {
       <button
         type="submit"
         disabled={isSubmitting}
-        className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+        className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-ring"
       >
         {isSubmitting ? (
           <>
@@ -143,7 +143,7 @@ export const LoginPage: React.FC = () => {
       {/* Sign Up Link */}
       <p className="text-center text-gray-600 text-sm">
         Don&apos;t have an account?{' '}
-        <Link href="/auth/register" className="text-blue-600 hover:text-blue-700 font-semibold">
+        <Link href="/auth/register" className="text-blue-600 hover:text-blue-700 font-semibold focus-ring rounded">
           Sign up
         </Link>
       </p>

--- a/frontend-v2/src/features/auth/pages/PasswordResetPage.tsx
+++ b/frontend-v2/src/features/auth/pages/PasswordResetPage.tsx
@@ -103,10 +103,10 @@ export const PasswordResetPage: React.FC = () => {
             type="text"
             placeholder="123456"
             maxLength={6}
-            className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition tracking-widest text-center text-lg ${
+            className={`w-full px-4 py-3 border rounded-lg focus-ring transition tracking-widest text-center text-lg ${
               codeForm.formState.errors.code
                 ? 'border-red-300 focus-visible:ring-red-500'
-                : 'border-gray-300 focus-visible:ring-blue-500'
+                : 'border-gray-300'
             }`}
             {...codeForm.register('code')}
           />
@@ -117,7 +117,7 @@ export const PasswordResetPage: React.FC = () => {
         <button
           type="submit"
           disabled={codeForm.formState.isSubmitting}
-          className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+          className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-ring"
         >
           {codeForm.formState.isSubmitting ? (
             <><div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />Verifying...</>
@@ -153,10 +153,10 @@ export const PasswordResetPage: React.FC = () => {
             id="password"
             type="password"
             placeholder="••••••••"
-            className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition ${
+            className={`w-full px-4 py-3 border rounded-lg focus-ring transition ${
               resetForm.formState.errors.password
                 ? 'border-red-300 focus-visible:ring-red-500'
-                : 'border-gray-300 focus-visible:ring-blue-500'
+                : 'border-gray-300'
             }`}
             {...resetForm.register('password')}
           />
@@ -172,10 +172,10 @@ export const PasswordResetPage: React.FC = () => {
             id="confirmPassword"
             type="password"
             placeholder="••••••••"
-            className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition ${
+            className={`w-full px-4 py-3 border rounded-lg focus-ring transition ${
               resetForm.formState.errors.confirmPassword
                 ? 'border-red-300 focus-visible:ring-red-500'
-                : 'border-gray-300 focus-visible:ring-blue-500'
+                : 'border-gray-300'
             }`}
             {...resetForm.register('confirmPassword')}
           />
@@ -186,7 +186,7 @@ export const PasswordResetPage: React.FC = () => {
         <button
           type="submit"
           disabled={resetForm.formState.isSubmitting}
-          className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+          className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-ring"
         >
           {resetForm.formState.isSubmitting ? (
             <><div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />Resetting...</>
@@ -215,10 +215,10 @@ export const PasswordResetPage: React.FC = () => {
           id="email"
           type="email"
           placeholder="you@example.com"
-          className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition ${
+          className={`w-full px-4 py-3 border rounded-lg focus-ring transition ${
             emailForm.formState.errors.email
               ? 'border-red-300 focus-visible:ring-red-500'
-              : 'border-gray-300 focus-visible:ring-blue-500'
+              : 'border-gray-300'
           }`}
           {...emailForm.register('email')}
         />
@@ -229,7 +229,7 @@ export const PasswordResetPage: React.FC = () => {
       <button
         type="submit"
         disabled={emailForm.formState.isSubmitting}
-        className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+        className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-ring"
       >
         {emailForm.formState.isSubmitting ? (
           <><div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />Sending...</>

--- a/frontend-v2/src/features/auth/pages/RegisterPage.tsx
+++ b/frontend-v2/src/features/auth/pages/RegisterPage.tsx
@@ -74,10 +74,10 @@ export const RegisterPage: React.FC = () => {
           id="fullName"
           type="text"
           placeholder="John Doe"
-          className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition ${
+          className={`w-full px-4 py-3 border rounded-lg focus-ring transition ${
             errors.fullName
               ? 'border-red-300 focus-visible:ring-red-500'
-              : 'border-gray-300 focus-visible:ring-blue-500'
+              : 'border-gray-300'
           }`}
           {...register('fullName')}
         />
@@ -96,10 +96,10 @@ export const RegisterPage: React.FC = () => {
           type="email"
           placeholder="you@example.com"
           autoComplete="email"
-          className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition ${
+          className={`w-full px-4 py-3 border rounded-lg focus-ring transition ${
             errors.email
               ? 'border-red-300 focus-visible:ring-red-500'
-              : 'border-gray-300 focus-visible:ring-blue-500'
+              : 'border-gray-300'
           }`}
           {...register('email')}
         />
@@ -119,10 +119,10 @@ export const RegisterPage: React.FC = () => {
             type={showPassword ? 'text' : 'password'}
             placeholder="••••••••"
             autoComplete="new-password"
-            className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition pr-12 ${
+            className={`w-full px-4 py-3 border rounded-lg focus-ring transition pr-12 ${
               errors.password
                 ? 'border-red-300 focus-visible:ring-red-500'
-                : 'border-gray-300 focus-visible:ring-blue-500'
+                : 'border-gray-300'
             }`}
             {...register('password')}
           />
@@ -130,7 +130,7 @@ export const RegisterPage: React.FC = () => {
             type="button"
             aria-label={showPassword ? 'Hide password' : 'Show password'}
             onClick={() => setShowPassword(!showPassword)}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 rounded"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition focus-ring rounded"
           >
             {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
           </button>
@@ -150,10 +150,10 @@ export const RegisterPage: React.FC = () => {
             id="confirmPassword"
             type={showConfirm ? 'text' : 'password'}
             placeholder="••••••••"
-            className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition pr-12 ${
+            className={`w-full px-4 py-3 border rounded-lg focus-ring transition pr-12 ${
               errors.confirmPassword
                 ? 'border-red-300 focus-visible:ring-red-500'
-                : 'border-gray-300 focus-visible:ring-blue-500'
+                : 'border-gray-300'
             }`}
             {...register('confirmPassword')}
           />
@@ -161,7 +161,7 @@ export const RegisterPage: React.FC = () => {
             type="button"
             aria-label={showConfirm ? 'Hide confirm password' : 'Show confirm password'}
             onClick={() => setShowConfirm(!showConfirm)}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 rounded"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition focus-ring rounded"
           >
             {showConfirm ? <EyeOff size={20} /> : <Eye size={20} />}
           </button>
@@ -175,7 +175,7 @@ export const RegisterPage: React.FC = () => {
       <button
         type="submit"
         disabled={isSubmitting}
-        className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+        className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-ring"
       >
         {isSubmitting ? (
           <>
@@ -190,7 +190,7 @@ export const RegisterPage: React.FC = () => {
       {/* Login Link */}
       <p className="text-center text-gray-600 text-sm">
         Already have an account?{' '}
-        <Link href="/auth/login" className="text-blue-600 hover:text-blue-700 font-semibold">
+        <Link href="/auth/login" className="text-blue-600 hover:text-blue-700 font-semibold focus-ring rounded">
           Sign in
         </Link>
       </p>

--- a/frontend-v2/src/features/auth/pages/VerifyEmailPage.tsx
+++ b/frontend-v2/src/features/auth/pages/VerifyEmailPage.tsx
@@ -25,7 +25,7 @@ export const VerifyEmailPage: React.FC = () => {
         </p>
         <Link
           href="/auth/login"
-          className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 px-4 rounded-lg transition text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+          className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 px-4 rounded-lg transition text-center focus-ring"
         >
           Back to Login
         </Link>

--- a/frontend-v2/src/features/courses/components/CourseFilterBar.tsx
+++ b/frontend-v2/src/features/courses/components/CourseFilterBar.tsx
@@ -56,7 +56,7 @@ export const CourseFilterBar: React.FC<CourseFilterBarProps> = ({ onSearch, onFi
               placeholder="Search courses, instructors, topics..."
               value={searchQuery}
               onChange={(e) => handleSearch(e.target.value)}
-              className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+              className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus-ring focus:border-transparent"
             />
           </div>
 
@@ -64,7 +64,7 @@ export const CourseFilterBar: React.FC<CourseFilterBarProps> = ({ onSearch, onFi
           <select
             value={filters.sortBy}
             onChange={(e) => handleFilterChange({ sortBy: e.target.value })}
-            className="hidden md:block px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            className="hidden md:block px-4 py-3 border border-gray-300 rounded-lg focus-ring focus:border-transparent"
           >
             {sortOptions.map((option) => (
               <option key={option.value} value={option.value}>

--- a/frontend-v2/src/features/courses/components/courseCard.tsx
+++ b/frontend-v2/src/features/courses/components/courseCard.tsx
@@ -80,7 +80,7 @@ export function CourseCard({
           onClick={() => toggle(String(id))}
           aria-label={wishlisted ? `Remove ${title} from wishlist` : `Add ${title} to wishlist`}
           aria-pressed={wishlisted}
-          className="absolute top-3 right-3 bg-white rounded-full p-2 shadow-md hover:shadow-lg transition-all hover:scale-110"
+          className="absolute top-3 right-3 bg-white rounded-full p-2 shadow-md hover:shadow-lg transition-all hover:scale-110 focus-ring"
         >
           <Heart
             size={18}

--- a/frontend-v2/src/features/courses/pages/CoursesPage.tsx
+++ b/frontend-v2/src/features/courses/pages/CoursesPage.tsx
@@ -98,7 +98,7 @@ function CourseGrid() {
             placeholder="Search courses..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-10 pr-12 py-3 border border-gray-300 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            className="w-full pl-10 pr-12 py-3 border border-gray-300 rounded-lg bg-white focus-ring focus:border-transparent"
           />
           {/* #783 — "/" shortcut hint badge */}
           <kbd className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden sm:inline-flex items-center gap-1 rounded border border-gray-300 bg-gray-100 px-1.5 py-0.5 text-xs font-mono text-gray-500 select-none">

--- a/frontend-v2/src/features/instructors/components/CourseForm.tsx
+++ b/frontend-v2/src/features/instructors/components/CourseForm.tsx
@@ -62,8 +62,8 @@ export const CourseForm: React.FC<CourseFormProps> = ({
         <input
           type="text"
           placeholder="Course title"
-          className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 transition ${
-            errors.title ? 'border-red-300 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+          className={`w-full px-4 py-3 border rounded-lg focus-ring transition ${
+            errors.title ? 'border-red-300 focus-visible:ring-red-500' : 'border-gray-300'
           }`}
           {...register('title')}
         />
@@ -76,8 +76,8 @@ export const CourseForm: React.FC<CourseFormProps> = ({
         <textarea
           rows={4}
           placeholder="Course description"
-          className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 transition resize-none ${
-            errors.description ? 'border-red-300 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+          className={`w-full px-4 py-3 border rounded-lg focus-ring transition resize-none ${
+            errors.description ? 'border-red-300 focus-visible:ring-red-500' : 'border-gray-300'
           }`}
           {...register('description')}
         />
@@ -89,8 +89,8 @@ export const CourseForm: React.FC<CourseFormProps> = ({
         <div>
           <label className="block text-sm font-semibold text-gray-700 mb-2">Category</label>
           <select
-            className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 transition ${
-              errors.category ? 'border-red-300 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+            className={`w-full px-4 py-3 border rounded-lg focus-ring transition ${
+              errors.category ? 'border-red-300 focus-visible:ring-red-500' : 'border-gray-300'
             }`}
             {...register('category')}
           >
@@ -105,8 +105,8 @@ export const CourseForm: React.FC<CourseFormProps> = ({
         <div>
           <label className="block text-sm font-semibold text-gray-700 mb-2">Level</label>
           <select
-            className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 transition ${
-              errors.level ? 'border-red-300 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+            className={`w-full px-4 py-3 border rounded-lg focus-ring transition ${
+              errors.level ? 'border-red-300 focus-visible:ring-red-500' : 'border-gray-300'
             }`}
             {...register('level')}
           >
@@ -127,8 +127,8 @@ export const CourseForm: React.FC<CourseFormProps> = ({
           step="0.01"
           min="0"
           placeholder="0.00"
-          className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 transition ${
-            errors.price ? 'border-red-300 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+          className={`w-full px-4 py-3 border rounded-lg focus-ring transition ${
+            errors.price ? 'border-red-300 focus-visible:ring-red-500' : 'border-gray-300'
           }`}
           {...register('price')}
         />
@@ -141,7 +141,7 @@ export const CourseForm: React.FC<CourseFormProps> = ({
         <input
           type="text"
           placeholder="https://example.com/image.jpg"
-          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus-ring transition"
           {...register('thumbnailUrl')}
         />
       </div>

--- a/frontend-v2/src/features/notifications/components/NotificationBell.tsx
+++ b/frontend-v2/src/features/notifications/components/NotificationBell.tsx
@@ -79,7 +79,7 @@ export function NotificationBell() {
         aria-haspopup="true"
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
-        className="relative p-2 rounded-lg hover:bg-gray-100 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+        className="relative p-2 rounded-lg hover:bg-gray-100 transition focus-ring"
       >
         <Bell size={20} className="text-gray-600" />
         {unreadCount > 0 && (

--- a/frontend-v2/src/features/students/pages/StudentDashboardPage.tsx
+++ b/frontend-v2/src/features/students/pages/StudentDashboardPage.tsx
@@ -122,11 +122,11 @@ export const StudentDashboardPage: React.FC = () => {
                       aria-valuenow={enrollment.progress}
                       aria-valuemin={0}
                       aria-valuemax={100}
-                      aria-label={`${enrollment.courseId} progress`}
-                      className="w-full bg-gray-200 rounded-full h-2 overflow-hidden"
+                      aria-label={`${enrollment.courseId} — ${enrollment.progress}% complete`}
+                      className="w-full bg-gray-200 rounded-full h-2"
                     >
                       <div
-                        className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+                        className="bg-indigo-600 h-2 rounded-full"
                         style={{ width: `${enrollment.progress}%` }}
                       />
                     </div>

--- a/frontend-v2/src/shared/components/layout/NavBar.tsx
+++ b/frontend-v2/src/shared/components/layout/NavBar.tsx
@@ -61,7 +61,7 @@ export const Navbar = () => {
             <button
               onClick={toggleMenu}
               type="button"
-              className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none min-h-[44px] min-w-[44px]"
+              className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus-ring min-h-[44px] min-w-[44px]"
               aria-controls="mobile-menu"
               aria-expanded={isOpen}
             >

--- a/frontend-v2/src/shared/components/ui/Button.tsx
+++ b/frontend-v2/src/shared/components/ui/Button.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import clsx from "clsx";
 import { colors } from '@/src/shared/constants/design-tokens';
+import { focusRing } from '@/src/shared/constants/a11y';
 type Variant = "primary" | "secondary" | "outline" | "ghost" | "destructive";
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: Variant;
@@ -27,7 +28,8 @@ export const Button: React.FC<ButtonProps> = ({
         ...style,
       } as React.CSSProperties}
       className={clsx(
-        "px-4 py-2 rounded-md transition focus:outline-none focus:ring-2 focus:ring-offset-2",
+        "px-4 py-2 rounded-md transition",
+        focusRing,
         variantStyles[variant],
         className,
       )}

--- a/frontend-v2/src/shared/components/ui/Modal.tsx
+++ b/frontend-v2/src/shared/components/ui/Modal.tsx
@@ -74,7 +74,7 @@ export const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }
           )}
           <button
             onClick={onClose}
-            className="ml-auto text-gray-400 hover:text-gray-600 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
+            className="ml-auto text-gray-400 hover:text-gray-600 transition focus-ring rounded"
             aria-label="Close modal"
           >
             ✕

--- a/frontend-v2/src/shared/components/ui/input.tsx
+++ b/frontend-v2/src/shared/components/ui/input.tsx
@@ -53,7 +53,7 @@ export const Input: React.FC<InputProps> = ({
         aria-describedby={error ? `${inputId}-error` : helperText ? `${inputId}-hint` : undefined}
         className={clsx(
           'w-full px-3 py-2 border rounded-md transition',
-          'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1',
+          'focus-ring',
           error
             ? 'border-red-500 focus-visible:ring-red-500 bg-red-50'
             : 'border-gray-300 focus-visible:ring-blue-500 bg-white',

--- a/frontend-v2/src/shared/constants/a11y.ts
+++ b/frontend-v2/src/shared/constants/a11y.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared keyboard focus ring for interactive elements.
+ * Prefer this over bare `focus:outline-none` so keyboard users can track focus.
+ */
+export const focusRing =
+  'focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2';

--- a/frontend-v2/src/shared/constants/index.ts
+++ b/frontend-v2/src/shared/constants/index.ts
@@ -1,0 +1,2 @@
+export { focusRing } from './a11y';
+export * from './design-tokens';

--- a/frontend-v2/src/store/settings/TwoFactorModal.tsx
+++ b/frontend-v2/src/store/settings/TwoFactorModal.tsx
@@ -57,7 +57,7 @@ export function BiometricLoginView({
       {/* Fallback Link */}
       <button
         onClick={onSwitchToEmail}
-        className="text-sm text-gray-900 hover:text-gray-700 focus:outline-none focus:underline"
+        className="text-sm text-gray-900 hover:text-gray-700 focus-ring"
       >
         Having trouble? Use email login
       </button>


### PR DESCRIPTION
## Summary
Accessibility improvements across frontend-v2: screen-reader text for course ratings, ARIA attributes on student progress bars, labeled password toggles, and a shared keyboard focus ring for interactive elements.

## Changes

### 1. CourseCard star rating — screen reader text
Stars alone convey rating visually; assistive tech had no equivalent.

- Confirmed/kept visually-hidden copy after the star group:
  `Rated {rating} out of 5 stars`
- Star icons remain `aria-hidden` so the rating is announced once via the `sr-only` text

**File:** `frontend-v2/src/features/courses/components/courseCard.tsx`

### 2. Student progress bars — ARIA progressbar
Progress UI was (or risked being) plain styled `div`s with no semantics.

- Progress track uses `role="progressbar"` with:
  - `aria-valuenow` / `aria-valuemin={0}` / `aria-valuemax={100}`
  - `aria-label` in the form `{courseId} — {progress}% complete`
- Fill uses indigo styling consistent with the design system

**File:** `frontend-v2/src/features/students/pages/StudentDashboardPage.tsx`

### 3. Password toggle buttons — `aria-label`
Show/hide controls are icon-only; screen readers need an explicit name.

- Login and Register toggles use:
  `aria-label={showPassword ? 'Hide password' : 'Show password'}`
- Confirm-password toggle keeps an equivalent labeled control

**Files:**
- `frontend-v2/src/features/auth/pages/LoginPage.tsx`
- `frontend-v2/src/features/auth/pages/RegisterPage.tsx`

### 4. Shared focus-visible ring for keyboard users
Many controls used `focus:outline-none` (or mouse-only `focus:ring`) without a visible keyboard indicator.

- Added shared utility class `focus-ring`:
  `focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2`
- Defined as:
  - CSS `@utility focus-ring` in `globals.css`
  - TS constant `focusRing` in `src/shared/constants/a11y.ts` (used by shared `Button`)
- Applied across interactive elements (buttons, inputs, selects, nav, forms, auth links, etc.)

**Key files:**
- `frontend-v2/app/globals.css`
- `frontend-v2/src/shared/constants/a11y.ts`
- Shared UI + auth/forms/nav/profile/contact/courses surfaces under `frontend-v2/`

## Test plan
- [ ] Course cards: with a screen reader (or Accessibility tree), rating announces as “Rated X out of 5 stars”
- [ ] Student dashboard progress bars expose `progressbar` role, value, and descriptive label
- [ ] Login/Register: password eye button announces “Show password” / “Hide password”
- [ ] Tab through nav, forms, auth, course filters, profile, and contact — indigo focus ring appears on keyboard focus only (not on mouse click)
- [ ] Error states on forms still show a red focus ring override where applicable

closes #774 
closes #775 
closes #776 
closes #779