### PR TITLE
ci: add Playwright e2e step and refresh PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,19 @@
-## Description  
-<!-- Provide a brief summary of the changes in this PR. Explain what was modified and why. -->  
+## What does this PR do?
 
-## Related Issues  
-<!-- Link any related issues using `Closes #issue_number` or `Fixes #issue_number`. This helps track bugs and feature requests. -->  
+## Related issue
+Closes #
 
-## Changes Made  
-- [ ] <!-- List key changes made in this PR. Use bullet points for clarity. -->  
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Responsiveness fix
+- [ ] Refactor
+- [ ] Test
 
-## How to Test  
-<!-- Explain how a reviewer can test these changes. Provide commands, steps, or expected results if applicable. -->  
+## How was this tested?
+- [ ] Unit tests added/updated
+- [ ] Tested on mobile (< 375px)
+- [ ] Tested on tablet (768px)
+- [ ] Tested on desktop (1280px+)
 
-## Screenshots (if applicable)  
-<!-- If your PR affects the UI, upload screenshots to show the changes visually. -->  
-
-## Checklist  
-- [ ] My code follows the project's coding style.  
-- [ ] I have tested these changes locally.  
-- [ ] Documentation has been updated where necessary.  
+## Screenshots (for UI changes)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,9 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm test
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+      - name: Run E2E tests
+        run: npm run test:e2e
+        env:
+          NEXT_PUBLIC_API_BASE_URL: http://localhost:3002


### PR DESCRIPTION
## What does this PR do?

Improves CI coverage and contributor PR quality:

1. **Playwright e2e in CI** — `playwright.config.ts` and `e2e/` already existed, but CI only ran unit tests. After `npm test`, the workflow now installs Chromium with OS deps and runs `npm run test:e2e` with `NEXT_PUBLIC_API_BASE_URL=http://localhost:3002`.

2. **PR template** — Replaces the old free-form template with a structured one: summary, linked issue (`Closes #`), change type checkboxes, test evidence (unit + breakpoints), and screenshots for UI work.

3. **CourseCard wishlist a11y** — Verified already fixed on `main`: the heart button exposes `aria-label` (`Add/Remove ${title} from wishlist`) and `aria-pressed` for screen readers. No further change required.

## Related issue
Closes #

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Responsiveness fix
- [ ] Refactor
- [x] Test

## How was this tested?
- [ ] Unit tests added/updated
- [ ] Tested on mobile (< 375px)
- [ ] Tested on tablet (768px)
- [ ] Tested on desktop (1280px+)
- [x] Verified CI workflow YAML includes Install Playwright + Run E2E steps after unit tests
- [x] Verified `.github/PULL_REQUEST_TEMPLATE.md` matches the required sections
- [x] Verified CourseCard wishlist button already has `aria-label` / `aria-pressed`

## Screenshots (for UI changes)
N/A — CI and docs-only changes (a11y already present on main).

## Files changed
- `.github/workflows/ci.yml` — Playwright install + e2e run after unit tests
- `.github/PULL_REQUEST_TEMPLATE.md` — structured contributor template

closes #773 
closes #795
closes #796