### PR TITLE
Route-ownership ratchet test, canonical import map, feature-boundary doc (#820-#822)

### DIFF
--- a/frontend-v2/docs/feature-boundaries.md
+++ b/frontend-v2/docs/feature-boundaries.md
@@ -1,0 +1,23 @@
+# Feature Boundaries (issue #822)
+
+`src/features/*` modules can currently import any file from any other
+feature, including private internals, making cross-feature cycles easy to
+introduce by accident.
+
+## Rule
+
+- A feature may only import from another feature's **public entrypoint**
+  (`src/features/<name>/index.ts`), never from its internal `components/`,
+  `hooks/`, or `services/` subfolders directly.
+- Shared code that multiple features need belongs in `src/lib`, `src/hooks`,
+  or `src/services` — not in another feature.
+- Dependency direction is one-way: `app/` and `src/app/` routes may import
+  features; features may import shared layers; shared layers may not import
+  features.
+
+## Enforcement (next step)
+
+Wire this up with `eslint-plugin-import`'s `no-restricted-paths`, restricting
+each `src/features/<name>` zone to only `src/features/<name>/index.ts` in
+other zones. That dependency isn't installed yet, so this doc captures the
+agreed rule first; the lint rule is a follow-up once the plugin is added.

--- a/frontend-v2/src/shared/canonical-imports.ts
+++ b/frontend-v2/src/shared/canonical-imports.ts
@@ -1,0 +1,20 @@
+/**
+ * Canonical import map for issue #821.
+ * frontend-v2 has parallel top-level and src-level lib/hooks/services
+ * directories (e.g. `lib/query-client.ts` vs `src/lib/query-client.ts`).
+ * This documents the single canonical path new code should import from
+ * until the duplicates are removed and callers migrated.
+ */
+
+export const CANONICAL_IMPORTS = {
+  queryClient: '@/src/lib/query-client',
+  apiClient: '@/src/lib/api-client',
+  authStore: '@/src/store/authStore',
+  walletContext: '@/src/context/WalletContext',
+} as const;
+
+/**
+ * Paths still duplicated outside `src/`; do not add new imports from these —
+ * migrate call sites to the matching entry in CANONICAL_IMPORTS instead.
+ */
+export const DEPRECATED_DUPLICATE_PATHS = ['@/lib/query-client'] as const;

--- a/frontend-v2/test/route-manifest.test.ts
+++ b/frontend-v2/test/route-manifest.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Route ownership guard for issue #820.
+ * frontend-v2 has route files under both `app/` and `src/app/`, making
+ * Next.js route discovery ambiguous. `dashboard/student/transactions` is a
+ * pre-existing duplicate tracked for consolidation; this test ratchets
+ * against any *new* route being defined in both trees.
+ */
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(__dirname, '..');
+const ROUTE_FILE = /^page\.(t|j)sx?$/;
+const KNOWN_DUPLICATES = new Set(['dashboard/student/transactions']);
+
+function collectRoutes(base: string): Set<string> {
+  const routes = new Set<string>();
+  if (!fs.existsSync(base)) return routes;
+
+  function walk(dir: string) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (ROUTE_FILE.test(entry.name)) {
+        routes.add(path.relative(base, dir).split(path.sep).join('/'));
+      }
+    }
+  }
+  walk(base);
+  return routes;
+}
+
+describe('route ownership', () => {
+  it('has no new route defined in both app/ and src/app/', () => {
+    const appRoutes = collectRoutes(path.join(ROOT, 'app'));
+    const srcAppRoutes = collectRoutes(path.join(ROOT, 'src', 'app'));
+
+    const duplicates = [...appRoutes].filter((route) => srcAppRoutes.has(route));
+    const unexpected = duplicates.filter((route) => !KNOWN_DUPLICATES.has(route));
+
+    expect(unexpected, `New duplicate routes in app/ and src/app/: ${unexpected.join(', ')}`).toEqual(
+      [],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `test/route-manifest.test.ts`: fails on any *new* route defined in both `app/` and `src/app/`, while explicitly tracking the one pre-existing duplicate (`dashboard/student/transactions`) so it doesn't silently spread further. Verified locally with `npx vitest run` — passing.
- Adds `src/shared/canonical-imports.ts`: documents the single canonical import path for each concern currently duplicated between top-level and `src/`-level `lib`/`hooks`/`services`
- Adds `docs/feature-boundaries.md`: documents the intended one-way dependency direction (routes → features → shared) and the public-entrypoint-only rule for cross-feature imports, ahead of wiring up `eslint-plugin-import`'s `no-restricted-paths`

Each fix is small and additive so it can be built on incrementally without touching existing files.

Closes #820
Closes #821
Closes #822