### PR TITLE
Enhance course and profile pages with cancellable timeouts for redire…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .env
 
+# dependencies (workspace hoist may place these at repo root)
+node_modules/
+
 # logs
 *.log
 debug.log

--- a/frontend-v2/app/(main)/instructors/courses/[id]/edit/page.tsx
+++ b/frontend-v2/app/(main)/instructors/courses/[id]/edit/page.tsx
@@ -4,12 +4,14 @@ import React, { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { CourseForm, CourseFormData } from '@/features/instructors/components/CourseForm';
 import { useCourseById, useUpdateCourse, useRemoveCourse } from '@/features/courses/hooks/useCourses';
+import { useCancellableTimeout } from '@/src/hooks/useCancellableTimeout';
 
 export default function EditCoursePage() {
   const params = useParams();
   const router = useRouter();
   const courseId = params.id as string;
   const [toast, setToast] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const redirectTimeout = useCancellableTimeout();
 
   const { data: course, isLoading, error } = useCourseById(courseId);
   const updateCourse = useUpdateCourse();
@@ -23,7 +25,7 @@ export default function EditCoursePage() {
         payload: { title: data.title, description: data.description, thumbnailUrl: data.thumbnailUrl, price: data.price },
       });
       setToast({ type: 'success', message: 'Course updated successfully!' });
-      setTimeout(() => router.push('/instructors/dashboard'), 1500);
+      redirectTimeout.schedule(() => router.push('/instructors/dashboard'), 1500);
     } catch {
       setToast({ type: 'error', message: 'Failed to update course. Please try again.' });
     }

--- a/frontend-v2/app/(main)/instructors/courses/create/page.tsx
+++ b/frontend-v2/app/(main)/instructors/courses/create/page.tsx
@@ -3,10 +3,12 @@
 import React, { useState } from 'react';
 import { CourseForm, CourseFormData } from '@/features/instructors/components/CourseForm';
 import { courseService } from '@/features/courses/services/course.service';
+import { useCancellableTimeout } from '@/src/hooks/useCancellableTimeout';
 
 export default function CreateCoursePage() {
   const [loading, setLoading] = useState(false);
   const [toast, setToast] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const redirectTimeout = useCancellableTimeout();
 
   const handleSubmit = async (data: CourseFormData, action: 'draft' | 'publish' | 'update') => {
     setLoading(true);
@@ -19,7 +21,7 @@ export default function CreateCoursePage() {
         price: data.price,
       });
       setToast({ type: 'success', message: `Course ${action === 'publish' ? 'published' : 'saved as draft'} successfully!` });
-      setTimeout(() => {
+      redirectTimeout.schedule(() => {
         window.location.href = '/instructors/dashboard';
       }, 1500);
     } catch {

--- a/frontend-v2/app/(main)/profile/page.tsx
+++ b/frontend-v2/app/(main)/profile/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useCancellableTimeout } from '@/src/hooks/useCancellableTimeout';
 
 interface ProfileFormValues {
   firstName: string;
@@ -30,6 +31,8 @@ export default function ProfilePage() {
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
   const [passwordStatus, setPasswordStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
   const [passwordError, setPasswordError] = useState<string | null>(null);
+  const saveStatusTimeout = useCancellableTimeout();
+  const passwordStatusTimeout = useCancellableTimeout();
 
   const handleProfileSave = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -47,7 +50,7 @@ export default function ProfilePage() {
         }),
       });
       setSaveStatus('saved');
-      setTimeout(() => setSaveStatus('idle'), 3000);
+      saveStatusTimeout.schedule(() => setSaveStatus('idle'), 3000);
     } catch {
       setSaveStatus('error');
     }
@@ -77,7 +80,7 @@ export default function ProfilePage() {
       });
       setPasswordStatus('saved');
       setPasswords({ currentPassword: '', newPassword: '', confirmPassword: '' });
-      setTimeout(() => setPasswordStatus('idle'), 3000);
+      passwordStatusTimeout.schedule(() => setPasswordStatus('idle'), 3000);
     } catch {
       setPasswordStatus('error');
     }

--- a/frontend-v2/app/dashboard/student/certificates/page.tsx
+++ b/frontend-v2/app/dashboard/student/certificates/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Award, Download, Share2, Loader2 } from 'lucide-react';
 import { useWallet } from '@/src/context/WalletContext';
 import { useSession } from '@/src/features/auth/hooks/useSession';
+import { useCancellableTimeout } from '@/src/hooks/useCancellableTimeout';
 
 interface Certificate {
   courseId: string;
@@ -88,17 +89,18 @@ export default function CertificatesPage() {
   const { token } = useSession();
   const [certs, setCerts] = useState<Certificate[]>([]);
   const [loading, setLoading] = useState(false);
+  const { schedule: scheduleLoad } = useCancellableTimeout();
 
   useEffect(() => {
     if (!publicKey || !token) return;
     setLoading(true);
     // TODO: fetch completed courses from backend, then call contracts.getCertificate() for each
     // Using mock data until contract integration is ready
-    setTimeout(() => {
+    scheduleLoad(() => {
       setCerts(MOCK_CERTIFICATES);
       setLoading(false);
     }, 500);
-  }, [publicKey, token]);
+  }, [publicKey, token, scheduleLoad]);
 
   if (!isConnected || !publicKey) {
     return (

--- a/frontend-v2/src/hooks/__tests__/useCancellableTimeout.test.ts
+++ b/frontend-v2/src/hooks/__tests__/useCancellableTimeout.test.ts
@@ -1,0 +1,107 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useCancellableTimeout } from "../useCancellableTimeout"
+
+describe("useCancellableTimeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("runs the callback after the delay", () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useCancellableTimeout())
+
+    act(() => {
+      result.current.schedule(callback, 1500)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(1499)
+    })
+    expect(callback).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it("replaces a prior timer when schedule is called again", () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const { result } = renderHook(() => useCancellableTimeout())
+
+    act(() => {
+      result.current.schedule(first, 1500)
+    })
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    act(() => {
+      result.current.schedule(second, 1500)
+    })
+    act(() => {
+      vi.advanceTimersByTime(1500)
+    })
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+
+  it("cancels a pending navigation callback on unmount (race)", () => {
+    const navigate = vi.fn()
+    const { result, unmount } = renderHook(() => useCancellableTimeout())
+
+    act(() => {
+      result.current.schedule(() => {
+        navigate("/instructors/dashboard")
+      }, 1500)
+    })
+
+    unmount()
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it("cancels a pending status-reset callback on unmount", () => {
+    const setStatus = vi.fn()
+    const { result, unmount } = renderHook(() => useCancellableTimeout())
+
+    act(() => {
+      result.current.schedule(() => setStatus("idle"), 3000)
+    })
+
+    unmount()
+
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+
+    expect(setStatus).not.toHaveBeenCalled()
+  })
+
+  it("clear() cancels a pending timer without unmounting", () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useCancellableTimeout())
+
+    act(() => {
+      result.current.schedule(callback, 1000)
+    })
+    act(() => {
+      result.current.clear()
+    })
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+})

--- a/frontend-v2/src/hooks/index.ts
+++ b/frontend-v2/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './useLocalStorage';
 export * from './useWindowSize';
 export * from './useDebounce';
 export * from './useSession';
+export * from './useCancellableTimeout';

--- a/frontend-v2/src/hooks/useCancellableTimeout.ts
+++ b/frontend-v2/src/hooks/useCancellableTimeout.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useRef } from "react"
+
+/**
+ * Schedules a delayed callback that is cleared on unmount.
+ * Calling `schedule` again replaces any pending timer (no stacking).
+ * Use for status resets and post-success redirects that must not fire after unmount.
+ */
+export function useCancellableTimeout() {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clear = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  const schedule = useCallback(
+    (fn: () => void, delayMs: number) => {
+      clear()
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        fn()
+      }, delayMs)
+    },
+    [clear]
+  )
+
+  useEffect(() => clear, [clear])
+
+  return { schedule, clear }
+}


### PR DESCRIPTION
## Summary
- Adds `useCancellableTimeout` so delayed UI callbacks (status resets, redirects, mock loads) are cleared on unmount and replaced when rescheduled.
- Wires the hook into profile settings, student certificates, and instructor create/edit course pages that previously used bare `setTimeout`.
- Adds fake-timer unit tests covering delay, timer replacement, and navigation/status races after unmount.

Closes #865

## Changes Made
- `frontend-v2/src/hooks/useCancellableTimeout.ts` — shared cancellable timeout hook
- `frontend-v2/src/hooks/__tests__/useCancellableTimeout.test.ts` — fake-timer coverage
- `frontend-v2/app/(main)/profile/page.tsx` — cancel profile/password status reset timers
- `frontend-v2/app/dashboard/student/certificates/page.tsx` — cancel mock certificate load timer
- `frontend-v2/app/(main)/instructors/courses/create/page.tsx` — cancel post-create redirect
- `frontend-v2/app/(main)/instructors/courses/[id]/edit/page.tsx` — cancel post-update redirect
- `frontend-v2/src/hooks/index.ts` — export hook
- `.gitignore` — ignore root `node_modules/` from workspace hoist

## How to Test
- [ ] `cd frontend-v2 && npm test -- src/hooks/__tests__/useCancellableTimeout.test.ts` passes
- [ ] Save profile twice quickly — only one status reset fires; navigating away before 3s does not error
- [ ] Create/update a course, leave the page before redirect — no navigation after unmount
- [ ] Certificates page: connect then leave before load completes — no state update after unmount